### PR TITLE
Add wildcard support and relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,28 +64,6 @@ The example uses [Configurable Links](https://reactnavigation.org/docs/configuri
 
 Example setup for example setup see [App.tsx](../App.tsx).
 
-### Wildcard support
-
-Currently user needs to manually add every webview to the React Navigation linking config.
-
-```ts
-const webviewScreensConfig = {
-  [Routes.New]: `${BASE_URL}/new`,
-  [Routes.Two]: `${BASE_URL}/two`,
-  [Routes.One]: `${BASE_URL}/one`,
-};
-```
-
-But we are working on supporting wildcard that would support a group of webview routes.
-
-```ts
-const webviewScreensConfig = {
-  [Routes.Webview]: {
-    path: `${BASE_URL}/*`,
-  },
-};
-```
-
 ## Examples
 
 You can see all the examples in action, just check out the example app. You need to first start the local demo web page from the [demo directory](../demo/).
@@ -96,19 +74,24 @@ You need to use the [useWebviewNavigate](../src/useWebviewNavigate.ts) hook whic
 
 ```ts
 const navigateTo = useWebviewNavigate();
-navigateTo(url, actionType /* "replace" | "advance" */);
+navigateTo(urlOrPath, actionType /* "replace" | "advance" */);
 ```
 
 ### Opening RN screen from webview
 
 In the linking object in the `<NavigationContainer/>` you need to define the url/route that opens specific screen.
 
+You can also add a wildcard path that will be navigated to on all URLs matching the prefixes, but not matching any other defined screens.
+
 ```ts
 const linking = {
   prefixes: [BASE_URL],
   config: {
     screens: {
-      NativeNumbersScreenName: 'https://turbo-native-demo.glitch.me/numbers',
+      NativeNumbersScreenName: '/numbers',
+      FallbackScreen: {
+        path: '*'
+      }
     },
   },
 };
@@ -118,15 +101,13 @@ When you open this link in the webview, you will automatically be taken to a scr
 
 ### Opening webview screen from a webview
 
-Unfortunately, currently you have to define both screens in linking config.
-
 ```ts
 const linking: LinkingOptions<any> = {
   prefixes: [BASE_URL],
   config: {
     screens: {
-      FirstScreen: 'https://turbo-native-demo.glitch.me/firstScreen',
-      SecondScreen: 'https://turbo-native-demo.glitch.me/secondScreen',
+      FirstScreen: '/firstScreen',
+      SecondScreen: '/secondScreen',
     },
   },
 };
@@ -145,11 +126,11 @@ const onVisitError = ({
   switch (statusCode) {
     case 401: {
       // Open sign in screen
-      navigateTo(`${BASE_URL}/signin`);
+      navigateTo(`/signin`);
       break;
     }
     default: {
-      navigateTo(`${BASE_URL}/notfound`, 'replace');
+      navigateTo(`/notfound`, 'replace');
     }
   }
 };

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ const linking = {
   prefixes: [BASE_URL],
   config: {
     screens: {
-      NativeNumbersScreenName: '/numbers',
+      NativeNumbersScreenName: 'numbers', // Will be shown when navigating to BASE_URL/numbers
       FallbackScreen: {
         path: '*'
       }
@@ -106,8 +106,8 @@ const linking: LinkingOptions<any> = {
   prefixes: [BASE_URL],
   config: {
     screens: {
-      FirstScreen: '/firstScreen',
-      SecondScreen: '/secondScreen',
+      FirstScreen: 'firstScreen',
+      SecondScreen: 'secondScreen',
     },
   },
 };
@@ -126,11 +126,11 @@ const onVisitError = ({
   switch (statusCode) {
     case 401: {
       // Open sign in screen
-      navigateTo(`/signin`);
+      navigateTo(`signin`);
       break;
     }
     default: {
-      navigateTo(`/notfound`, 'replace');
+      navigateTo(`notfound`, 'replace');
     }
   }
 };

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,24 +16,13 @@ interface Props {}
 const Stack = createNativeStackNavigator<any>();
 
 const webviewScreensConfig: PathConfigMap<any> = {
-  [Routes.WebviewInitial]: `${BASE_URL}`,
-  [Routes.New]: `${BASE_URL}/new`,
-  [Routes.Two]: `${BASE_URL}/two`,
-  [Routes.One]: `${BASE_URL}/one`,
-  [Routes.Slow]: `${BASE_URL}/slow`,
-  [Routes.NumbersScreen]: `${BASE_URL}/numbers`,
-  [Routes.LongScreen]: `${BASE_URL}/long`,
-  [Routes.SuccessScreen]: `${BASE_URL}/success`,
-  [Routes.NonExistentScreen]: `${BASE_URL}/nonexistent`,
-  [Routes.SignIn]: `${BASE_URL}/signin`,
-  [Routes.Protected]: `${BASE_URL}/protected`,
-  [Routes.NotFound]: `${BASE_URL}/notfound`,
-  [Routes.Files]: `${BASE_URL}/files`,
-  [Routes.Follow]: `${BASE_URL}/follow`,
-  [Routes.Redirected]: `${BASE_URL}/redirected`,
-  [Routes.Share]: `${BASE_URL}/share`,
-  [Routes.NotFound]: {
-    path: `${BASE_URL}/*`,
+  [Routes.WebviewInitial]: `/`,
+  [Routes.New]: `/new`,
+  [Routes.SuccessScreen]: `/success`,
+  [Routes.NumbersScreen]: `/numbers`,
+  [Routes.SignIn]: `/signin`,
+  [Routes.Fallback]: {
+    path: '*',
   },
 };
 
@@ -79,29 +68,9 @@ const App: React.FC<Props> = () => {
             options={{ title: 'Turbo Native Demo' }}
           />
           <Stack.Screen
-            name={Routes.One}
-            component={WebviewScreen}
-            options={{ title: "How'd You Get Here?" }}
-          />
-          <Stack.Screen
-            name={Routes.Two}
-            component={WebviewScreen}
-            options={{ title: 'Push or Replace?' }}
-          />
-          <Stack.Screen
-            name={Routes.Slow}
-            component={WebviewScreen}
-            options={{ title: 'Slow-loading Page' }}
-          />
-          <Stack.Screen
             name={Routes.NumbersScreen}
             component={NumbersScreen}
             options={{ title: 'A List of Numbers' }}
-          />
-          <Stack.Screen
-            name={Routes.LongScreen}
-            component={WebviewScreen}
-            options={{ title: 'A Really Long Page' }}
           />
           <Stack.Screen
             name={Routes.New}
@@ -127,34 +96,14 @@ const App: React.FC<Props> = () => {
             options={{ title: 'Sign In', presentation: 'modal' }}
           />
           <Stack.Screen
-            name={Routes.Protected}
-            component={WebviewScreen}
-            options={{ title: 'Protected Webpage' }}
-          />
-          <Stack.Screen
-            name={Routes.Files}
-            component={WebviewScreen}
-            options={{ title: 'Handling Files' }}
-          />
-          <Stack.Screen
-            name={Routes.Follow}
-            component={WebviewScreen}
-            options={{ title: 'Redirected Page' }}
-          />
-          <Stack.Screen
-            name={Routes.Redirected}
-            component={WebviewScreen}
-            options={{ title: 'Redirected Page' }}
-          />
-          <Stack.Screen
             name={Routes.NotFound}
             component={ErrorScreen}
             options={{ title: 'Not Found' }}
           />
           <Stack.Screen
-            name={Routes.Share}
+            name={Routes.Fallback}
             component={WebviewScreen}
-            options={{ title: 'Try Sharing' }}
+            options={{ title: '' }}
           />
         </Stack.Navigator>
       </Session>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -16,11 +16,11 @@ interface Props {}
 const Stack = createNativeStackNavigator<any>();
 
 const webviewScreensConfig: PathConfigMap<any> = {
-  [Routes.WebviewInitial]: `/`,
-  [Routes.New]: `/new`,
-  [Routes.SuccessScreen]: `/success`,
-  [Routes.NumbersScreen]: `/numbers`,
-  [Routes.SignIn]: `/signin`,
+  [Routes.WebviewInitial]: ``,
+  [Routes.New]: `new`,
+  [Routes.SuccessScreen]: `success`,
+  [Routes.NumbersScreen]: `numbers`,
+  [Routes.SignIn]: `signin`,
   [Routes.Fallback]: {
     path: '*',
   },

--- a/example/src/WebviewScreen.tsx
+++ b/example/src/WebviewScreen.tsx
@@ -36,7 +36,7 @@ const WebviewScreen: React.FC<Props> = ({ navigation, route }) => {
         break;
       }
       default: {
-        navigateTo(`${BASE_URL}/notfound`, 'replace');
+        navigation.replace(Routes.NotFound);
       }
     }
   };

--- a/example/src/WebviewScreen.tsx
+++ b/example/src/WebviewScreen.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View, NativeSyntheticEvent } from 'react-native';
-import { BASE_URL } from './config';
+import { BASE_URL, Routes } from './config';
 import {
   VisitableView,
   OnLoadEvent,
@@ -19,7 +19,8 @@ interface Props {
 const WebviewScreen: React.FC<Props> = ({ navigation, route }) => {
   const navigateTo = useWebviewNavigate();
 
-  const currentUrl = route?.path || BASE_URL;
+  const path = route?.params?.path || route?.path;
+  const currentUrl = path ? `${BASE_URL}${path}` : BASE_URL;
 
   const onVisitProposal = ({
     nativeEvent: { action: actionType, url },
@@ -32,7 +33,7 @@ const WebviewScreen: React.FC<Props> = ({ navigation, route }) => {
   }: NativeSyntheticEvent<VisitProposalError>) => {
     switch (statusCode) {
       case 401: {
-        navigateTo(`${BASE_URL}/signin`);
+        navigateTo(`/signin`);
         break;
       }
       default: {

--- a/example/src/WebviewScreen.tsx
+++ b/example/src/WebviewScreen.tsx
@@ -33,7 +33,7 @@ const WebviewScreen: React.FC<Props> = ({ navigation, route }) => {
   }: NativeSyntheticEvent<VisitProposalError>) => {
     switch (statusCode) {
       case 401: {
-        navigateTo(`/signin`);
+        navigateTo(`signin`);
         break;
       }
       default: {

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -20,5 +20,5 @@ export enum Routes {
   Follow = 'Follow',
   Redirected = 'Redirected',
   Share = 'Share',
-  Fallback = 'Fallback'
+  Fallback = 'Fallback',
 }

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -20,4 +20,5 @@ export enum Routes {
   Follow = 'Follow',
   Redirected = 'Redirected',
   Share = 'Share',
+  Fallback = 'Fallback'
 }

--- a/example/src/config.ts
+++ b/example/src/config.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = 'http://localhost:45678';
+export const BASE_URL = 'http://localhost:45678/';
 
 export enum Routes {
   TabBar = 'TabBar',

--- a/src/useWebviewNavigate.ts
+++ b/src/useWebviewNavigate.ts
@@ -5,6 +5,7 @@ import {
 } from '@react-navigation/core';
 import * as React from 'react';
 import LinkingContext from '@react-navigation/native/src/LinkingContext';
+import extractPathFromURL from '@react-navigation/native/src/extractPathFromURL';
 import type { Action } from './types';
 
 type To<
@@ -46,9 +47,13 @@ export default function useWebviewNavigate<
 
       const { options } = linking;
 
+      const path = to.match(/^https?:\/\//)
+        ? extractPathFromURL(options?.prefixes, to)
+        : to;
+
       const state = options?.getStateFromPath
-        ? options.getStateFromPath(to, options.config)
-        : getStateFromPath(to, options?.config);
+        ? options.getStateFromPath(path, options.config)
+        : getStateFromPath(`${path}`, options?.config);
 
       if (state) {
         const action = getActionFromState(state, options?.config);


### PR DESCRIPTION
This PR adds support for defining the screen URLs relatively, following the React Navigation Linking conventions.

It also adds wildcard screen matching in the example app.