### PR TITLE
Fix crashes on going back on android

### DIFF
--- a/packages/core/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/core/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -58,6 +58,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), TurboSessionCal
     override fun detachWebView(callback: () -> Unit) {
         screenshot = turboView.createScreenshot()
         turboView.addScreenshot(screenshot)
+        (session.turboSession.webView.parent as ViewGroup)?.endViewTransition(session.turboSession.webView)
         turboView.detachWebView(session.turboSession.webView) {
             Log.d("RNVisitableView", "webView detached ${visit}")
             callback()


### PR DESCRIPTION
Woah, this was a painful one.

I've tried to write the logic for running addView and removeView manually, and I've noticed that calling removeView sometimes works and sometimes doesn't change `isAttachedToWindow` which causes a fail when adding it to another container.

I think it's somehow related to RNscreens animations. Overall, the fix seems to work for me, but hope it works in your testing.