### PR TITLE
Adds support for cookie auth and an auth example

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,7 +8,7 @@ import { buildWebScreen, WebScreenRuleConfig } from 'react-native-web-screen';
 import { default as NativeScreen } from './NumbersScreen';
 import ErrorScreen from './ErrorScreen';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
-import { OnErrorCallback, Session } from 'react-native-turbo';
+import { OnErrorCallback, Session, withSession } from 'react-native-turbo';
 
 const Stack = createNativeStackNavigator();
 const Tab = createMaterialTopTabNavigator();
@@ -123,7 +123,7 @@ const App: React.FC = () => {
           />
           <Stack.Screen
             name={Routes.NestedTab}
-            component={NestedTab}
+            component={withSession(NestedTab)}
             options={{ title: 'Nested Top Tab' }}
           />
         </Stack.Navigator>

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
-import { NavigationContainer } from '@react-navigation/native';
+import React, { useCallback } from 'react';
+import {
+  NavigationContainer,
+  useNavigationContainerRef,
+} from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { buildWebScreen, WebScreenRuleConfig } from 'react-native-web-screen';
 import { default as NativeScreen } from './NumbersScreen';
 import ErrorScreen from './ErrorScreen';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
+import { OnErrorCallback, Session } from 'react-native-turbo';
 
 const Stack = createNativeStackNavigator();
 const Tab = createMaterialTopTabNavigator();
@@ -80,36 +84,51 @@ const NestedTab: React.FC = () => {
 };
 
 const App: React.FC = () => {
+  const navigation = useNavigationContainerRef<any>();
+
+  const handleVisitError = useCallback<OnErrorCallback>(
+    (error) => {
+      const notLoggedIn = error.statusCode === 401;
+      if (notLoggedIn) {
+        navigation.goBack();
+        navigation.navigate(Routes.SignIn, { path: 'signin' });
+      }
+    },
+    [navigation]
+  );
+
   return (
-    <NavigationContainer linking={webScreens.linking}>
-      <Stack.Navigator
-        screenOptions={{
-          headerBackTitle: 'Back',
-          headerTintColor: '#00094a',
-        }}
-      >
-        <Stack.Screen {...webScreens.screens.WebviewInitial} />
-        <Stack.Screen
-          name={Routes.NumbersScreen}
-          component={NativeScreen}
-          options={{ title: 'A List of Numbers' }}
-        />
-        <Stack.Screen {...webScreens.screens.New} />
-        <Stack.Screen {...webScreens.screens.SuccessScreen} />
-        <Stack.Screen {...webScreens.screens.SignIn} />
-        <Stack.Screen {...webScreens.screens.Fallback} />
-        <Stack.Screen
-          name={Routes.NotFound}
-          component={ErrorScreen}
-          options={{ title: 'Not Found' }}
-        />
-        <Stack.Screen
-          name={Routes.NestedTab}
-          component={NestedTab}
-          options={{ title: 'Nested Top Tab' }}
-        />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <Session onVisitError={handleVisitError}>
+      <NavigationContainer linking={webScreens.linking} ref={navigation}>
+        <Stack.Navigator
+          screenOptions={{
+            headerBackTitle: 'Back',
+            headerTintColor: '#00094a',
+          }}
+        >
+          <Stack.Screen {...webScreens.screens.WebviewInitial} />
+          <Stack.Screen
+            name={Routes.NumbersScreen}
+            component={NativeScreen}
+            options={{ title: 'A List of Numbers' }}
+          />
+          <Stack.Screen {...webScreens.screens.New} />
+          <Stack.Screen {...webScreens.screens.SuccessScreen} />
+          <Stack.Screen {...webScreens.screens.SignIn} />
+          <Stack.Screen {...webScreens.screens.Fallback} />
+          <Stack.Screen
+            name={Routes.NotFound}
+            component={ErrorScreen}
+            options={{ title: 'Not Found' }}
+          />
+          <Stack.Screen
+            name={Routes.NestedTab}
+            component={NestedTab}
+            options={{ title: 'Nested Top Tab' }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </Session>
   );
 };
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -1,6 +1,5 @@
 package com.reactnativeturbowebview
 
-import android.app.Activity
 import android.util.Log
 import android.webkit.JavascriptInterface
 import androidx.appcompat.app.AppCompatActivity

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionModule.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionModule.kt
@@ -6,7 +6,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.module.annotations.ReactModule
-import java.util.UUID
+import java.util.*
 
 private const val MODULE_NAME = "RNSessionModule"
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -2,6 +2,7 @@ package com.reactnativeturbowebview
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.util.Log
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatImageView
@@ -292,6 +293,14 @@ class RNVisitableView(context: Context, sessionModule: RNSessionModule) : Linear
     if (isWebViewAttachedToNewDestination) {
       showProgressView()
     }
+  }
+
+  override fun requestFailedWithStatusCode(visitHasCachedSnapshot: Boolean, statusCode: Int) {
+    super.requestFailedWithStatusCode(visitHasCachedSnapshot, statusCode)
+    sendEvent(RNVisitableViewEvent.VISIT_ERROR, Arguments.createMap().apply {
+      putInt("statusCode", statusCode)
+      putString("url", webView.url)
+    })
   }
 
   // end region

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -288,8 +288,9 @@ class RNVisitableView(context: Context, sessionModule: RNSessionModule) : Linear
       putString("title", webView.title)
       putString("url", webView.url)
     })
-    val cookieManager = CookieManager.getInstance()
-    cookieManager.flush()
+    CookieManager
+      .getInstance()
+      .flush()
   }
 
   override fun visitLocationStarted(location: String) {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
 import android.view.ViewGroup
+import android.webkit.CookieManager
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.lifecycle.Lifecycle
@@ -287,6 +288,8 @@ class RNVisitableView(context: Context, sessionModule: RNSessionModule) : Linear
       putString("title", webView.title)
       putString("url", webView.url)
     })
+    val cookieManager = CookieManager.getInstance()
+    cookieManager.flush()
   }
 
   override fun visitLocationStarted(location: String) {

--- a/packages/turbo/src/Session.tsx
+++ b/packages/turbo/src/Session.tsx
@@ -5,6 +5,7 @@ import { SessionContext } from './SessionContext';
 import type {
   SessionModule,
   SessionMessageCallback,
+  OnErrorCallback,
 } from 'packages/turbo/src/types';
 
 const RNSessionModule = getNativeModule<SessionModule>('RNSessionModule');
@@ -15,6 +16,7 @@ interface Message {
 
 export interface Props {
   onMessage?: SessionMessageCallback;
+  onVisitError?: OnErrorCallback;
 }
 
 interface State {
@@ -79,9 +81,10 @@ export default class Session extends React.Component<Props, State> {
 
   render() {
     const { sessionHandle } = this.state;
+    const { onVisitError } = this.props;
 
     return (
-      <SessionContext.Provider value={{ sessionHandle }}>
+      <SessionContext.Provider value={{ sessionHandle, onVisitError }}>
         {this.props.children}
       </SessionContext.Provider>
     );

--- a/packages/turbo/src/SessionContext.ts
+++ b/packages/turbo/src/SessionContext.ts
@@ -1,9 +1,12 @@
+import type { OnErrorCallback } from 'packages/turbo/src/types';
 import React from 'react';
 
 interface SessionContextValue {
   sessionHandle?: string | null;
+  onVisitError?: OnErrorCallback;
 }
 
 export const SessionContext = React.createContext<SessionContextValue>({
   sessionHandle: undefined,
+  onVisitError: undefined,
 });

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -26,3 +26,5 @@ export interface SessionModule {
     callbackStringified: string
   ) => Promise<unknown>;
 }
+
+export type OnErrorCallback = (error: VisitProposalError) => void;


### PR DESCRIPTION
This pull request adds support for cookies authorization and persistence in the Android application. The changes use android CookieManager to persist cookies between app runs.

Adds auth session example to the example app.