### PR TITLE
Fix onMessage not working on iOS

### DIFF
--- a/example/server/views/share.ejs
+++ b/example/server/views/share.ejs
@@ -4,8 +4,12 @@
       method: 'share',
       shareText: 'Hello from the webview 👋',
     };
-    AndroidInterface.postMessage(JSON.stringify({ message }));
-    webkit.messageHandlers.nativeApp.postMessage(message);
+    if (typeof AndroidInterface !== 'undefined') {
+      AndroidInterface.postMessage(JSON.stringify({ message }));
+    }
+    if (typeof webkit !== 'undefined') {
+      webkit.messageHandlers.nativeApp.postMessage(message);
+    }
   }
 
   function shared() {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,7 +6,12 @@ import {
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { default as NativeScreen } from './NumbersScreen';
 import ErrorScreen from './ErrorScreen';
-import { OnErrorCallback, Session, withSession } from 'react-native-turbo';
+import {
+  SessionMessageCallback,
+  OnErrorCallback,
+  Session,
+  withSession,
+} from 'react-native-turbo';
 import { Routes, webScreens } from 'example/src/webScreen';
 import NestedTab from 'example/src/NestedTab';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
@@ -46,8 +51,13 @@ const App: React.FC = () => {
     [navigation]
   );
 
+  const onMessageHandler = useCallback<SessionMessageCallback>(
+    (message) => console.log(message),
+    []
+  );
+
   return (
-    <Session onVisitError={handleVisitError}>
+    <Session onMessage={onMessageHandler} onVisitError={handleVisitError}>
       <NavigationContainer linking={webScreens.linking} ref={navigation}>
         <Stack.Navigator
           screenOptions={{

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionModule.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionModule.kt
@@ -53,4 +53,11 @@ class RNSessionModule(private val reactContext: ReactApplicationContext) :
       }
     }
   }
+
+  // Required methods for NativeEventEmitter calls
+  @ReactMethod
+  fun addListener(type: String?) { }
+
+  @ReactMethod
+  fun removeListeners(type: Int?) { }
 }

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -11,9 +11,17 @@ import WebKit
 
 class RNSession: NSObject {
   
-  @objc var onMessage: RCTDirectEventBlock?
   private var registeredVisitableViews: [SessionSubscriber] = []
-  
+  private var eventEmitter: RCTEventEmitter? = nil
+  private var sessionHandle: NSString = "defaultHandle"
+    
+  override init() { }
+    
+  init(eventEmitter: RCTEventEmitter, sessionHandle: NSString){
+    self.eventEmitter = eventEmitter
+    self.sessionHandle = sessionHandle
+  }
+    
   public lazy var turboSession: Session = {
     let configuration = WKWebViewConfiguration()
     configuration.userContentController.add(self, name: "nativeApp")
@@ -49,8 +57,7 @@ class RNSession: NSObject {
 extension RNSession: WKScriptMessageHandler {
   
   func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-    onMessage?(["message": message.body])
+    eventEmitter?.sendEvent(withName: "sessionMessage" + (sessionHandle as String), body: ["message": message.body])
   }
   
 }
-

--- a/packages/turbo/ios/RNSessionModule.swift
+++ b/packages/turbo/ios/RNSessionModule.swift
@@ -12,6 +12,8 @@ class RNSessionModule: RCTEventEmitter {
   
   @objc
   private var sessions: [NSString: RNSession] = [:]
+    
+  @objc var supportedEventNames: [String] = []
   
   @objc
   private var defaultSession = RNSession()
@@ -21,7 +23,8 @@ class RNSessionModule: RCTEventEmitter {
     _ resolve: @escaping RCTPromiseResolveBlock,
     rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       let sessionHandle = UUID().uuidString as NSString
-      sessions[sessionHandle] = RNSession()
+      supportedEventNames.append("sessionMessage" + (sessionHandle as String))
+      sessions[sessionHandle] = RNSession(eventEmitter: self, sessionHandle: sessionHandle)
       resolve(sessionHandle)
   }
   
@@ -30,6 +33,9 @@ class RNSessionModule: RCTEventEmitter {
     _ sessionHandle: NSString,
     resolver resolve: @escaping RCTPromiseResolveBlock,
     rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+      if let index = supportedEventNames.firstIndex(of: "sessionMessage" + (sessionHandle as String)) {
+        supportedEventNames.remove(at: index)
+      }
       sessions[sessionHandle] = nil
   }
   
@@ -66,7 +72,7 @@ class RNSessionModule: RCTEventEmitter {
   }
   
   override func supportedEvents() -> [String]! {
-    return []
+    return supportedEventNames
   }
   
   override static func requiresMainQueueSetup() -> Bool {

--- a/packages/turbo/src/common.ts
+++ b/packages/turbo/src/common.ts
@@ -1,7 +1,7 @@
 import type { SessionMessageCallback } from 'packages/turbo/src/types';
 import type { EmitterSubscription } from 'react-native';
 import {
-  DeviceEventEmitter,
+  NativeEventEmitter,
   Platform,
   requireNativeComponent,
   UIManager,
@@ -17,6 +17,8 @@ const LINKING_ERROR =
 export enum SessionEvents {
   MESSAGE = 'MESSAGE',
 }
+
+const eventEmitter = new NativeEventEmitter(NativeModules.RNSessionModule);
 
 export function getNativeComponent<T>(componentName: string) {
   return UIManager.getViewManagerConfig(componentName) != null
@@ -44,5 +46,5 @@ export function registerMessageEventListener(
   onMessage: SessionMessageCallback
 ): EmitterSubscription {
   const eventName = `sessionMessage${sessionHandle}`;
-  return DeviceEventEmitter.addListener(eventName, onMessage);
+  return eventEmitter.addListener(eventName, onMessage);
 }


### PR DESCRIPTION
## Summary

This PR:
1. Fixes an issue with `onMessage` not working on iOS. The main issue was that on Android, when a message is sent from the website, the event is being sent and caught with a `DeviceEventEmitter` listener. However, on iOS, the event was not being sent at all.
2. Replaces `DeviceEventEmitter` with `NativeEventEmitter `because it is deprecated.
3. Checks for the existence of the `AndroidInterface` variable. When the app was loading the example website on iOS, screen sharing would not work because `AndroidInterface` is not defined on iOS.

## Test plan

Run the app on iOS device and check if messages from the website are shown in the console. 