### PR TITLE
Make user-agent of WebView customisable 

### DIFF
--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -78,6 +78,10 @@ URL for the WKWebview to open. Changing the url should result in view replacing 
 
 Session handle for the webview. If not provided, the default session will be used. It can be used to create separate webview instances for different parts of the app.
 
+### `applicationNameForUserAgent`
+
+The name of the application as used in the user agent string.
+
 ### `onVisitProposal`
 
 Callback called when the webview detects turbo visit action.

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -2,6 +2,7 @@ package com.reactnativeturbowebview
 
 import android.util.Log
 import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
@@ -15,6 +16,7 @@ import org.json.JSONObject
 class RNSession(
   private val reactContext: ReactApplicationContext,
   private val sessionHandle: String = "Default",
+  private val applicationNameForUserAgent: String? = "",
   private val registeredVisitableViews: MutableList<SessionSubscriber> = mutableListOf()
 ) {
 
@@ -25,6 +27,7 @@ class RNSession(
     val sessionName = UUID.randomUUID().toString()
     webView.getSettings().setJavaScriptEnabled(true)
     webView.addJavascriptInterface(JavaScriptInterface(), "AndroidInterface")
+    setUserAgentString(webView, applicationNameForUserAgent)
     val session = TurboSession(sessionName, activity, webView)
     session.isRunningInAndroidNavigation = false
     session
@@ -67,6 +70,14 @@ class RNSession(
 
   internal fun removeVisitableView(view: SessionSubscriber) {
     registeredVisitableViews.remove(view)
+  }
+
+  private fun setUserAgentString(webView: TurboWebView, applicationNameForUserAgent: String?){
+    var userAgentString = WebSettings.getDefaultUserAgent(webView.context)
+    if (applicationNameForUserAgent != null) {
+      userAgentString = "$userAgentString $applicationNameForUserAgent"
+    }
+    webView.settings.userAgentString = userAgentString
   }
 
   inner class JavaScriptInterface {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewModule.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewModule.kt
@@ -24,9 +24,9 @@ class RNVisitableViewModule(private val reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun setConfiguration(sessionHandle: String, promise: Promise) {
+  fun setConfiguration(sessionHandle: String, applicationNameForUserAgent: String?, promise: Promise) {
     if(!sessions.containsKey(sessionHandle)) {
-      sessions[sessionHandle] = lazy { RNSession(reactContext, sessionHandle) }
+      sessions[sessionHandle] = lazy { RNSession(reactContext, sessionHandle, applicationNameForUserAgent) }
     }
     promise.resolve(sessionHandle)
   }

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -14,6 +14,7 @@ class RNSession: NSObject {
   private var registeredVisitableViews: [SessionSubscriber] = []
   private var eventEmitter: RCTEventEmitter? = nil
   private var sessionHandle: NSString = "defaultHandle"
+  private var applicationNameForUserAgent: String? = nil
     
   override init() { }
     
@@ -22,9 +23,15 @@ class RNSession: NSObject {
     self.sessionHandle = sessionHandle
   }
     
+  convenience init(eventEmitter: RCTEventEmitter, sessionHandle: NSString, applicationNameForUserAgent: NSString?){
+    self.init(eventEmitter: eventEmitter, sessionHandle: sessionHandle)
+    self.applicationNameForUserAgent = applicationNameForUserAgent as String?
+  }
+  
   public lazy var turboSession: Session = {
     let configuration = WKWebViewConfiguration()
     configuration.userContentController.add(self, name: "nativeApp")
+    configuration.applicationNameForUserAgent = applicationNameForUserAgent
     return Session(webViewConfiguration: configuration)
   }()
   

--- a/packages/turbo/ios/RNVisitableViewModule.m
+++ b/packages/turbo/ios/RNVisitableViewModule.m
@@ -10,6 +10,7 @@
 @interface RCT_EXTERN_MODULE(RNVisitableViewModule, NSObject)
 
   RCT_EXTERN_METHOD(setConfiguration: (nonnull NSString) sessionHandle
+                    applicationNameForUserAgent: (NSString) applicationNameForUserAgent
                     resolver: (RCTPromiseResolveBlock) resolve
                     rejecter: (RCTPromiseRejectBlock) reject)
 

--- a/packages/turbo/ios/RNVisitableViewModule.swift
+++ b/packages/turbo/ios/RNVisitableViewModule.swift
@@ -21,10 +21,11 @@ class RNVisitableViewModule: RCTEventEmitter {
   @objc
   public func setConfiguration(
     _ sessionHandle: NSString,
+    applicationNameForUserAgent: NSString?,
     resolver resolve: @escaping RCTPromiseResolveBlock,
     rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
       if(sessions[sessionHandle] == nil){
-        sessions[sessionHandle] = RNSession(eventEmitter: self, sessionHandle: sessionHandle)
+        sessions[sessionHandle] = RNSession(eventEmitter: self, sessionHandle: sessionHandle, applicationNameForUserAgent: applicationNameForUserAgent)
         supportedEventNames.append("sessionMessage" + (sessionHandle as String))
       }
       resolve(sessionHandle)

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -31,6 +31,7 @@ const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
 export interface Props {
   url: string;
   sessionHandle?: string;
+  applicationNameForUserAgent?: string;
   onVisitProposal: (proposal: NativeSyntheticEvent<VisitProposal>) => void;
   onLoad?: (proposal: NativeSyntheticEvent<OnLoadEvent>) => void;
   onVisitError?: OnErrorCallback;
@@ -45,6 +46,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
   (props, ref) => {
     const {
       sessionHandle = 'Default',
+      applicationNameForUserAgent,
       onMessage,
       onVisitError: viewErrorHandler,
     } = props;
@@ -52,10 +54,13 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
 
     useEffect(() => {
       const setSessionConfiguration = async () => {
-        await RNVisitableViewModule.setConfiguration(sessionHandle);
+        await RNVisitableViewModule.setConfiguration(
+          sessionHandle,
+          applicationNameForUserAgent
+        );
       };
       setSessionConfiguration();
-    }, [sessionHandle]);
+    }, [sessionHandle, applicationNameForUserAgent]);
 
     useImperativeHandle(
       ref,

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -19,7 +19,10 @@ export interface VisitProposalError {
 export type SessionMessageCallback = (message: object) => void;
 
 export interface VisitableViewModule {
-  setConfiguration: (sessionHandle: string) => Promise<string>;
+  setConfiguration: (
+    sessionHandle: string,
+    applicationNameForUserAgent?: string
+  ) => Promise<string>;
   registerSession: () => Promise<string>;
   removeSession: (sessionHandle: string) => Promise<string>;
   injectJavaScript: (


### PR DESCRIPTION
This PR is dependent on #53. Because of this reason, please review last three commits only!

## Summary

This PR resolves #7: it adds support for custom user-agent in `Session` and `VisitableView` components.

## Test plan

Run the app where custom user-agent is being handled and check if there are any differences when using custom user-agent string.  