### PR TITLE
Support urls with query string

### DIFF
--- a/packages/navigation/src/useWebviewNavigate.ts
+++ b/packages/navigation/src/useWebviewNavigate.ts
@@ -74,10 +74,10 @@ export default function useWebviewNavigate<
 
       const { options } = linking;
 
-      const path =
-        (to.match(/^https?:\/\//)
-          ? extractPathFromURL(options?.prefixes, to)
-          : to) ?? '';
+      let path = to;
+      if (to.match(/^https?:\/\//)) {
+        path = extractPathFromURL(options?.prefixes, to) ?? '';
+      }
 
       /* We need to send the path name as screen param
       to the screen this way cause it works also for nested navigators */

--- a/packages/navigation/src/useWebviewNavigate.ts
+++ b/packages/navigation/src/useWebviewNavigate.ts
@@ -61,13 +61,23 @@ export default function useWebviewNavigate<
 
       const { options } = linking;
 
-      const path = to.match(/^https?:\/\//)
-        ? extractPathFromURL(options?.prefixes, to)
-        : to;
+      const path =
+        (to.match(/^https?:\/\//)
+          ? extractPathFromURL(options?.prefixes, to)
+          : to) ?? '';
 
       /* We need to send the path name as screen param
       to the screen this way cause it works also for nested navigators */
-      const pathWithScreenParams = `${path}?path=${path}`;
+      const queryStringIndex = path.indexOf('?');
+      let pathWithoutQueryString, queryString;
+      if (queryStringIndex !== -1) {
+        pathWithoutQueryString = path.slice(0, queryStringIndex);
+        queryString = path.slice(queryStringIndex + 1);
+      } else {
+        pathWithoutQueryString = path;
+        queryString = '';
+      }
+      const pathWithScreenParams = `${pathWithoutQueryString}?${queryString}&path=${pathWithoutQueryString}`;
 
       const state = options?.getStateFromPath
         ? options.getStateFromPath(pathWithScreenParams, options.config)

--- a/packages/navigation/src/useWebviewNavigate.ts
+++ b/packages/navigation/src/useWebviewNavigate.ts
@@ -37,6 +37,19 @@ type To<
           params: ParamList[RouteName];
         });
 
+const parseQueryStringFromPath = (path: string) => {
+  let pathWithoutQueryString = path;
+  let queryString = '';
+  const queryStringIndex = path.indexOf('?');
+
+  if (queryStringIndex !== -1) {
+    pathWithoutQueryString = path.slice(0, queryStringIndex);
+    queryString = path.slice(queryStringIndex + 1);
+  }
+
+  return { pathWithoutQueryString, queryString };
+};
+
 /*
  * Its like useLinkTo with some custom tweaks
  */
@@ -68,15 +81,8 @@ export default function useWebviewNavigate<
 
       /* We need to send the path name as screen param
       to the screen this way cause it works also for nested navigators */
-      const queryStringIndex = path.indexOf('?');
-      let pathWithoutQueryString, queryString;
-      if (queryStringIndex !== -1) {
-        pathWithoutQueryString = path.slice(0, queryStringIndex);
-        queryString = path.slice(queryStringIndex + 1);
-      } else {
-        pathWithoutQueryString = path;
-        queryString = '';
-      }
+      const { pathWithoutQueryString, queryString } =
+        parseQueryStringFromPath(path);
       const pathWithScreenParams = `${pathWithoutQueryString}?${queryString}&path=${pathWithoutQueryString}`;
 
       const state = options?.getStateFromPath


### PR DESCRIPTION
This PR fixes the problem in `useWebviewNavigate` hook -> urls with query string were not properly handled, causing `pathWithScreenParams` variable to have improper format. 