### PR TITLE
Fix not showing VisitableView when bottom tab has been changed on Android

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -196,6 +196,14 @@ class RNVisitableView(context: Context, sessionModule: RNSessionModule) : Linear
       return
     }
 
+    // Sometimes detachWebView is not called before attachWebView.
+    // This can happen when the user uses one session for different
+    // bottom tabs. In this case, we need to remove the webview from
+    // the parent before attaching it to the new one.
+    if(webView.parent != null){
+      (webView.parent as ViewGroup).removeView(webView)
+    }
+
     view.attachWebView(webView) { attachedToNewDestination ->
       onReady(attachedToNewDestination)
     }

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -46,4 +46,10 @@ class RNVisitableViewManager(
       sessionModule = reactContext.getNativeModule(RNSessionModule::class.java)!!
     )
 
+  override fun onDropViewInstance(view: RNVisitableView) {
+    view.detachWebView {
+      super.onDropViewInstance(view)
+    }
+  }
+
 }


### PR DESCRIPTION
This PR fixes a bug with bottom tabs. On Android if you switch bottom tabs, `detachWebView` is not being called, causing the `WebView` not to unmount on the native side. 