### PR TITLE
Fix native ActivityIndicator not being shown on Android

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -200,6 +200,10 @@ class RNVisitableView(context: Context, sessionModule: RNSessionModule) : Linear
     }
   }
 
+  /*
+   * Fixes a bug in React Native, causing improper layout of the TurboView and its children.
+   * Refer to https://github.com/facebook/react-native/issues/17968 for the detailed issue discussion and context.
+   */
   override fun requestLayout() {
     super.requestLayout()
     post(measureAndLayout)

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -2,7 +2,6 @@ package com.reactnativeturbowebview
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.util.Log
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.widget.LinearLayout
@@ -180,7 +179,7 @@ class RNVisitableView(context: Context, sessionModule: RNSessionModule) : Linear
   override fun detachWebView(onReady: () -> Unit) {
     screenshotView()
 
-    (session.webView.parent as ViewGroup)?.endViewTransition(session.webView)
+    (session.webView.parent as ViewGroup?)?.endViewTransition(session.webView)
 
     webViewContainer.post {
       webViewContainer.removeAllViews()
@@ -201,6 +200,19 @@ class RNVisitableView(context: Context, sessionModule: RNSessionModule) : Linear
     }
   }
 
+  override fun requestLayout() {
+    super.requestLayout()
+    post(measureAndLayout)
+  }
+
+  private val measureAndLayout = Runnable {
+    measure(
+      MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+      MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
+    )
+    layout(left, top, right, bottom)
+  }
+
   /**
    * Fixes initial size of WebView
    */
@@ -208,8 +220,6 @@ class RNVisitableView(context: Context, sessionModule: RNSessionModule) : Linear
     super.onLayout(changed, left, top, right, bottom)
     val width = right - left
     val height = bottom - top
-    webView.layout(0, 0, width, height)
-    turboView.layout(0, 0, width, height)
     screenshotView.layout(0, 0, width, height)
   }
 


### PR DESCRIPTION
On Android native progressView/ActivityIndicator was not visible when opening slow loading page. It was caused by react-native behavior: to achieve performance, not all native components are being re-laid. Also manually re-laying the progressView in `onLayout` didin't work as expected. A fix from [here](https://github.com/facebook/react-native/issues/17968) solved this issue.
