### PR TITLE
Open external links in an external browser

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNWebChromeClient.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNWebChromeClient.kt
@@ -3,6 +3,7 @@ package com.reactnativeturbowebview
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import android.os.Message
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
@@ -11,13 +12,26 @@ import com.facebook.react.bridge.ReactApplicationContext
 
 
 class RNWebChromeClient(
-  reactContext: ReactApplicationContext
+  private val reactContext: ReactApplicationContext
 ) : ActivityEventListener, WebChromeClient() {
 
   private val fileChooserDelegate = RNFileChooserDelegate(reactContext)
 
   init {
     reactContext.addActivityEventListener(this)
+  }
+
+  override fun onCreateWindow(
+    view: WebView?,
+    isDialog: Boolean,
+    isUserGesture: Boolean,
+    resultMsg: Message?
+  ): Boolean {
+    val result = view!!.hitTestResult
+    val data = result.extra
+    val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(data))
+    reactContext.startActivityForResult(browserIntent, 0, null)
+    return false
   }
 
   override fun onShowFileChooser(


### PR DESCRIPTION
This PR depends on #51. Please review [feat: open target=_blank links in the external browser](https://github.com/software-mansion-labs/react-native-turbo-demo/commit/44f3de59c0cede6910d006bd9397a6bcd44f02bb) only!

This PR ensures external links open in an external browser. Previously, no action was taken when clicking on a link with `target=_blank`.