### PR TITLE
Use replace navigation action

### DIFF
--- a/packages/navigation/src/useWebviewNavigate.ts
+++ b/packages/navigation/src/useWebviewNavigate.ts
@@ -2,6 +2,7 @@ import {
   getActionFromState,
   getStateFromPath,
   NavigationContainerRefContext,
+  StackActions,
 } from '@react-navigation/native';
 import * as React from 'react';
 import LinkingContext from '@react-navigation/native/src/LinkingContext';
@@ -99,7 +100,10 @@ export default function useWebviewNavigate<
         } else {
           const actionToDispatch =
             actionType === 'replace'
-              ? CommonActions.setParams({ path })
+              ? StackActions.replace(action.payload.name, {
+                  ...action.payload.params,
+                  __disable_animation: true,
+                })
               : CommonActions.navigate(action.payload.name, {
                   ...action.payload.params,
                 });

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -10,7 +10,11 @@ import {
   NativeSyntheticEvent,
   StyleSheet,
 } from 'react-native';
-import { getNativeModule, registerMessageEventListener } from './common';
+import {
+  getNativeComponent,
+  getNativeModule,
+  registerMessageEventListener,
+} from './common';
 import type {
   OnErrorCallback,
   OnLoadEvent,
@@ -25,8 +29,8 @@ import {
   NavigationContainerRefContext,
   useNavigation,
 } from '@react-navigation/native';
-import RNVisitableView from './RNVisitableView';
 
+const RNVisitableView = getNativeComponent<any>('RNVisitableView');
 const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
   'RNVisitableViewModule'
 );

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -64,7 +64,14 @@ function useDisableNavigationAnimation() {
       navigation.setOptions({
         animation: 'none',
       });
+      const timeout = setTimeout(() => {
+        navigation.setOptions({
+          animation: undefined,
+        });
+      }, 500);
+      return () => clearTimeout(timeout);
     }
+    return undefined;
   }, [navigation, navWithRoutes]);
 }
 

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -33,6 +33,8 @@ const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
 
 export interface Props {
   url: string;
+  navigation: any;
+  route: any;
   sessionHandle?: string;
   applicationNameForUserAgent?: string;
   stradaComponents?: StradaComponent[];
@@ -70,6 +72,14 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
           .join(' '),
       [applicationNameForUserAgent, stradaUserAgent]
     );
+
+    useEffect(() => {
+      if (props?.route?.params?.__disable_animation) {
+        props.navigation.setOptions({
+          animation: 'none',
+        });
+      }
+    }, []);
 
     useEffect(() => {
       const setSessionConfiguration = async () => {

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -68,7 +68,7 @@ function useDisableNavigationAnimation() {
         navigation.setOptions({
           animation: undefined,
         });
-      }, 500);
+      }, 100);
       return () => clearTimeout(timeout);
     }
     return undefined;


### PR DESCRIPTION
Use navigation.replace action to replace screens. Also disable animation for that actions, so it will look seamless.

Before only `path` param was updated (so screen content was reloaded).