### PR TITLE
Extract RNVisitableView and RNVisitableViewModule to separate files

### DIFF
--- a/packages/turbo/src/BridgeComponent.ts
+++ b/packages/turbo/src/BridgeComponent.ts
@@ -1,16 +1,12 @@
 import { Component } from 'react';
 import type { EmitterSubscription } from 'react-native';
 import type {
-  VisitableViewModule,
   StradaMessage,
   StradaMessages,
   StradaComponentProps,
 } from './types';
-import { getNativeModule, registerMessageEventListener } from './common';
-
-const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
-  'RNVisitableViewModule'
-);
+import { registerMessageEventListener } from './common';
+import RNVisitableViewModule from './RNVisitableViewModule';
 
 const registerStradaMessageEventListener = (component: BridgeComponent) =>
   registerMessageEventListener(component.name, (e: object) => {

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -1,14 +1,31 @@
-import { UIManager, requireNativeComponent } from 'react-native';
+import {
+  NativeSyntheticEvent,
+  StyleProp,
+  UIManager,
+  ViewStyle,
+  requireNativeComponent,
+} from 'react-native';
 import { LINKING_ERROR } from './common';
+import { VisitProposal, OnLoadEvent, VisitProposalError } from './types';
 
-export function getNativeComponent<T>(asdf: string) {
-  return UIManager.hasViewManagerConfig(asdf)
-    ? requireNativeComponent<T>(asdf)
+export function getNativeComponent<T>(componentName: string) {
+  return UIManager.hasViewManagerConfig(componentName)
+    ? requireNativeComponent<T>(componentName)
     : () => {
         throw new Error(LINKING_ERROR);
       };
 }
 
-const RNVisitableView = getNativeComponent<any>('RNVisitableView');
+export interface RNVisitableViewProps {
+  url: string;
+  sessionHandle?: string;
+  style?: StyleProp<ViewStyle>;
+  onVisitProposal: (proposal: NativeSyntheticEvent<VisitProposal>) => void;
+  onLoad?: (proposal: NativeSyntheticEvent<OnLoadEvent>) => void;
+  onVisitError?: (e: NativeSyntheticEvent<VisitProposalError>) => void;
+}
+
+const RNVisitableView =
+  getNativeComponent<RNVisitableViewProps>('RNVisitableView');
 
 export default RNVisitableView;

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -1,0 +1,14 @@
+import { UIManager, requireNativeComponent } from 'react-native';
+import { LINKING_ERROR } from './common';
+
+export function getNativeComponent<T>(asdf: string) {
+  return UIManager.hasViewManagerConfig(asdf)
+    ? requireNativeComponent<T>(asdf)
+    : () => {
+        throw new Error(LINKING_ERROR);
+      };
+}
+
+const RNVisitableView = getNativeComponent<any>('RNVisitableView');
+
+export default RNVisitableView;

--- a/packages/turbo/src/RNVisitableViewModule.ts
+++ b/packages/turbo/src/RNVisitableViewModule.ts
@@ -1,0 +1,36 @@
+import { NativeModules } from 'react-native';
+import { LINKING_ERROR } from './common';
+
+function getNativeModule<T>(moduleName: string): T {
+  return NativeModules[moduleName]
+    ? NativeModules[moduleName]
+    : new Proxy(
+        {},
+        {
+          get() {
+            throw new Error(LINKING_ERROR);
+          },
+        }
+      );
+}
+
+interface VisitableViewModule {
+  setConfiguration: (
+    sessionHandle: string,
+    applicationNameForUserAgent?: string
+  ) => Promise<string>;
+  registerSession: () => Promise<string>;
+  removeSession: (sessionHandle: string) => Promise<string>;
+  injectJavaScript: (
+    sessionHandle: string | null,
+    callbackStringified: string
+  ) => Promise<unknown>;
+  registerEvent: (eventName: string) => void;
+  unregisterEvent: (eventName: string) => void;
+}
+
+const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
+  'RNVisitableViewModule'
+);
+
+export default RNVisitableViewModule;

--- a/packages/turbo/src/Session.tsx
+++ b/packages/turbo/src/Session.tsx
@@ -1,18 +1,14 @@
-import { getNativeModule, registerMessageEventListener } from './common';
+import { registerMessageEventListener } from './common';
 import React, { RefObject } from 'react';
 import type { EmitterSubscription, NativeSyntheticEvent } from 'react-native';
 import type {
-  VisitableViewModule,
   SessionMessageCallback,
   OnErrorCallback,
 } from 'packages/turbo/src/types';
+import RNVisitableViewModule from './RNVisitableViewModule';
 
 const deprecationMessage =
   'Session component is no longer supported. Please refer to: https://github.com/software-mansion-labs/react-native-turbo-demo/pull/53#issue-1978014350 and https://github.com/software-mansion-labs/react-native-turbo-demo/blob/main/packages/turbo/README.md for more details.';
-
-const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
-  'RNVisitableViewModule'
-);
 
 interface Message {
   message: object;

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -10,22 +10,18 @@ import {
   NativeSyntheticEvent,
   StyleSheet,
 } from 'react-native';
-import { getNativeModule, registerMessageEventListener } from './common';
+import { registerMessageEventListener } from './common';
 import type {
   OnErrorCallback,
   OnLoadEvent,
   SessionMessageCallback,
-  VisitableViewModule,
   VisitProposal,
   VisitProposalError,
   StradaComponent,
 } from './types';
 import { useStradaBridge } from './stradaBridge';
 import RNVisitableView from './RNVisitableView';
-
-const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
-  'RNVisitableViewModule'
-);
+import RNVisitableViewModule from './RNVisitableViewModule';
 
 export interface Props {
   url: string;

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -14,25 +14,25 @@ import { registerMessageEventListener } from './common';
 import type {
   OnErrorCallback,
   OnLoadEvent,
-  SessionMessageCallback,
-  VisitProposal,
   VisitProposalError,
   StradaComponent,
+  SessionMessageCallback,
 } from './types';
 import { useStradaBridge } from './stradaBridge';
-import RNVisitableView from './RNVisitableView';
+import RNVisitableView, { RNVisitableViewProps } from './RNVisitableView';
 import RNVisitableViewModule from './RNVisitableViewModule';
 
-export interface Props {
+interface OwnProps {
   url: string;
   sessionHandle?: string;
   applicationNameForUserAgent?: string;
   stradaComponents?: StradaComponent[];
-  onVisitProposal: (proposal: NativeSyntheticEvent<VisitProposal>) => void;
-  onLoad?: (proposal: NativeSyntheticEvent<OnLoadEvent>) => void;
   onVisitError?: OnErrorCallback;
   onMessage?: SessionMessageCallback;
 }
+
+export type Props = OwnProps &
+  Pick<RNVisitableViewProps, 'onVisitProposal' | 'onLoad'>;
 
 export interface RefObject {
   injectJavaScript: (callbackStringified: string) => void;

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -10,11 +10,7 @@ import {
   NativeSyntheticEvent,
   StyleSheet,
 } from 'react-native';
-import {
-  getNativeComponent,
-  getNativeModule,
-  registerMessageEventListener,
-} from './common';
+import { getNativeModule, registerMessageEventListener } from './common';
 import type {
   OnErrorCallback,
   OnLoadEvent,
@@ -25,8 +21,8 @@ import type {
   StradaComponent,
 } from './types';
 import { useStradaBridge } from './stradaBridge';
+import RNVisitableView from './RNVisitableView';
 
-const RNVisitableView = getNativeComponent<any>('RNVisitableView');
 const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
   'RNVisitableViewModule'
 );

--- a/packages/turbo/src/common.ts
+++ b/packages/turbo/src/common.ts
@@ -17,19 +17,6 @@ const eventEmitter = new NativeEventEmitter(
   NativeModules.RNVisitableViewModule
 );
 
-export function getNativeModule<T>(moduleName: string): T {
-  return NativeModules[moduleName]
-    ? NativeModules[moduleName]
-    : new Proxy(
-        {},
-        {
-          get() {
-            throw new Error(LINKING_ERROR);
-          },
-        }
-      );
-}
-
 export function registerMessageEventListener(
   eventName: string,
   onMessage: SessionMessageCallback

--- a/packages/turbo/src/common.ts
+++ b/packages/turbo/src/common.ts
@@ -1,14 +1,9 @@
 import type { SessionMessageCallback } from 'packages/turbo/src/types';
 import type { EmitterSubscription } from 'react-native';
-import {
-  NativeEventEmitter,
-  Platform,
-  requireNativeComponent,
-  UIManager,
-} from 'react-native';
+import { NativeEventEmitter, Platform } from 'react-native';
 import { NativeModules } from 'react-native';
 
-const LINKING_ERROR =
+export const LINKING_ERROR =
   `The package react-native-turbo doesn't seem to be linked. Make sure: \n\n` +
   Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
   '- You rebuilt the app after installing the package\n' +
@@ -21,14 +16,6 @@ export enum SessionEvents {
 const eventEmitter = new NativeEventEmitter(
   NativeModules.RNVisitableViewModule
 );
-
-export function getNativeComponent<T>(componentName: string) {
-  return UIManager.getViewManagerConfig(componentName) != null
-    ? requireNativeComponent<T>(componentName)
-    : () => {
-        throw new Error(LINKING_ERROR);
-      };
-}
 
 export function getNativeModule<T>(moduleName: string): T {
   return NativeModules[moduleName]

--- a/packages/turbo/src/stradaBridge.ts
+++ b/packages/turbo/src/stradaBridge.ts
@@ -1,11 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { Platform } from 'react-native';
-import { getNativeModule } from './common';
-import type { VisitableViewModule, StradaComponent } from './types';
-
-const RNVisitableViewModule = getNativeModule<VisitableViewModule>(
-  'RNVisitableViewModule'
-);
+import type { StradaComponent } from './types';
+import RNVisitableViewModule from './RNVisitableViewModule';
 
 const stradaBridgeScript = `
 (() => {

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -29,21 +29,6 @@ export type StradaMessage = {
 
 export type SessionMessageCallback = (message: object) => void;
 
-export interface VisitableViewModule {
-  setConfiguration: (
-    sessionHandle: string,
-    applicationNameForUserAgent?: string
-  ) => Promise<string>;
-  registerSession: () => Promise<string>;
-  removeSession: (sessionHandle: string) => Promise<string>;
-  injectJavaScript: (
-    sessionHandle: string | null,
-    callbackStringified: string
-  ) => Promise<unknown>;
-  registerEvent: (eventName: string) => void;
-  unregisterEvent: (eventName: string) => void;
-}
-
 export type OnErrorCallback = (error: VisitProposalError) => void;
 
 export type StradaComponentProps = {


### PR DESCRIPTION
Refactor how `RNVisitableView` and `RNVisitableViewModule` are created. This should reduce number of app crashes  when package files are edited during development (with Hot Reload enabled), due to error:
```
Invariant Violation: Tried to register two views with the same name RNVisitableView, js engine: hermes
```

I've also added proper types to `RNVisitableView`, so they map what is passed to native code.