### PR TITLE
Disable link preview on iOS

### DIFF
--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -24,6 +24,7 @@ class RNSession: NSObject {
     webViewConfiguration.userContentController.add(self, name: "nativeApp")
     let session = Session(webViewConfiguration: webViewConfiguration)
     session.delegate = self
+    session.webView.allowsLinkPreview = false
     return session
   }()
   public lazy var webView: WKWebView = turboSession.webView


### PR DESCRIPTION
When user press longer on any link in app, Safari shows link preview by default. Let's disable it in app for now (in future we might want enable it as feature depending on configuration?)

| Before | After |
|--------|--------|
| <img src=https://github.com/software-mansion-labs/react-native-turbo-demo/assets/6529801/72e191ed-a3da-4c33-b91d-9b3afe52eb70 width=300 /> | <img src=https://github.com/software-mansion-labs/react-native-turbo-demo/assets/6529801/1efc40e0-0d62-4dea-a7cf-0f045673a249 width=300 /> | 


