### PR TITLE
Introduce a reload method to the VisitableView 

### DIFF
--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -173,6 +173,10 @@ const jsCode = "console.warn('foo')";
 injectJavaScript(jsCode);
 ```
 
+### `reload()`
+
+Reloads the webview.
+
 ## Session Component
 
 Session component has been deprecated. To use multiple [sessions](https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#session), you can use `sessionHandle` prop on `VisitableView` component.

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -90,7 +90,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     }
   }
 
-  private fun refresh(displayProgress: Boolean) {
+  internal fun refresh(displayProgress: Boolean) {
     if (webView.url == null) return
 
     turboView.webViewRefresh?.apply {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -15,7 +15,8 @@ enum class RNVisitableViewEvent(val jsCallbackName: String) {
 }
 
 enum class RNVisitableViewCommand(val jsCallbackName: String) {
-  INJECT_JAVASCRIPT("injectJavaScript")
+  INJECT_JAVASCRIPT("injectJavaScript"),
+  RELOAD_PAGE("reload")
 }
 
 private const val REACT_CLASS = "RNVisitableView"
@@ -54,6 +55,7 @@ class RNVisitableViewManager(
           root.injectJavaScript(it)
         }
       }
+      RNVisitableViewCommand.RELOAD_PAGE -> root.refresh(true)
     }
   }
 

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -50,6 +50,10 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     webView.evaluateJavaScript(code as String)
   }
     
+  public func reload(){
+    session.reload()
+  }
+    
   private func visit() {
     if(controller.visitableURL?.absoluteString == url as String) {
       return
@@ -65,7 +69,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   public func didProposeVisit(proposal: VisitProposal){
     if (webView.url == proposal.url) {
       // When reopening same URL we want to reload webview
-      session.reload()
+      reload()
     } else {
       let event: [AnyHashable: Any] = [
         "url": proposal.url.absoluteString,

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -22,6 +22,8 @@
 
   RCT_EXTERN_METHOD(injectJavaScript: (nonnull NSNumber) node
                     code: (nonnull NSString) code)
+  RCT_EXTERN_METHOD(reload: (nonnull NSNumber) node)
+
 
 @end
 

--- a/packages/turbo/ios/RNVisitableViewManager.swift
+++ b/packages/turbo/ios/RNVisitableViewManager.swift
@@ -26,6 +26,14 @@ class RNVisitableViewManager: RCTViewManager {
       component.injectJavaScript(code: code)
     }
   }
+    
+  @objc
+  func reload(_ node: NSNumber) {
+    DispatchQueue.main.async {
+      let component = self.bridge.uiManager.view(forReactTag: node) as! RNVisitableView
+      component.reload()
+    }
+  }
 
 }
 

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -45,7 +45,7 @@ function transformCommandToAcceptableType(command: number): number | string {
 export function dispatchCommand(
   ref: React.RefObject<any>,
   command: DispatchCommandTypes,
-  code: string
+  ...args: any[]
 ) {
   const viewConfig = UIManager.getViewManagerConfig('RNVisitableView');
 
@@ -56,7 +56,7 @@ export function dispatchCommand(
   UIManager.dispatchViewManagerCommand(
     findNodeHandle(ref.current),
     transformCommandToAcceptableType(viewConfig.Commands[command]!),
-    [code]
+    args
   );
 }
 

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -36,6 +36,7 @@ export interface Props {
 
 export interface RefObject {
   injectJavaScript: (callbackStringified: string) => void;
+  reload: () => void;
 }
 
 const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
@@ -72,13 +73,13 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
     useImperativeHandle(
       ref,
       () => ({
-        injectJavaScript: (callbackStringified) => {
+        injectJavaScript: (callbackStringified) =>
           dispatchCommand(
             visitableViewRef,
             'injectJavaScript',
             callbackStringified
-          );
-        },
+          ),
+        reload: () => dispatchCommand(visitableViewRef, 'reload'),
       }),
       []
     );

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -54,10 +54,10 @@ export type StradaMessages = {
 };
 
 // list of methods available for RNVisitableView module
-export type DispatchCommandTypes = 'injectJavaScript';
+export type DispatchCommandTypes = 'injectJavaScript' | 'reload';
 
 export type DispatchCommand = (
   ref: React.RefObject<any>,
   command: DispatchCommandTypes,
-  args: string
+  ...args: any[]
 ) => void;


### PR DESCRIPTION
This PR introduces a `reload` method to the `VisitableView`. This feature might be useful in scenarios where an error has occurred and reloading the page would be the desired recovery action.