### PR TITLE
Strada: Fix registration of multiple components

### DIFF
--- a/packages/turbo/src/hooks/useStradaBridge.ts
+++ b/packages/turbo/src/hooks/useStradaBridge.ts
@@ -123,15 +123,12 @@ export const useStradaBridge = (
   const initializeStradaBridge = useCallback(() => {
     dispatchCommand(visitableViewRef, 'injectJavaScript', stradaBridgeScript);
 
-    const stradaComponentNames =
-      stradaComponents
-        ?.map(({ componentName }) => `'${componentName}'`)
-        .join(',') || '';
+    const stradaComponentNames = stradaComponents?.map(({ componentName }) => componentName) || []
 
     dispatchCommand(
       visitableViewRef,
       'injectJavaScript',
-      `[${stradaComponentNames}].forEach(componentName => window.nativeBridge.register(componentName))`
+      `window.nativeBridge.register(${JSON.stringify(stradaComponentNames)})`
     );
   }, [dispatchCommand, stradaComponents, visitableViewRef]);
 


### PR DESCRIPTION
Previously `nativeBridge.register(..)` would be called multiple times - one for each component. This would make the the bridge adapter register after the _first_ component only, while subsequent component registrations didn't properly register on the web bridge.

The `NativeBridge#register` function takes an array of component names instead of a single one, so changing it to use this. This solves the issue we've seen with components not being picked up by the web bridge and pendingMessages being lost on the web side.