### PR TITLE
Fix app crash when using many tabs

### DIFF
--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -47,6 +47,9 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
   
   override func willMove(toWindow newWindow: UIWindow?) {
+    // visitableWillAppear is not called automatically sometimes. So it has to be called
+    // manually to make sure that visitableViews list is not empty
+    // see https://github.com/software-mansion-labs/react-native-turbo-demo/pull/81
     controller.viewWillAppear(false)
   }
     

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -45,6 +45,10 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     controller.didMove(toParent: reactViewController())
     addSubview(controller.view)
   }
+  
+  override func willMove(toWindow newWindow: UIWindow?) {
+    controller.viewWillAppear(false)
+  }
     
   public func handleMessage(message: WKScriptMessage) {
     if let messageBody = message.body as? [AnyHashable : Any] {


### PR DESCRIPTION
When app that uses `react-native-turbo` has many tabs, it often crashes. It is caused by calling `RNSession.unregisterVisitableView` when `visitableViews` list is empty.

@pklatka investigated it and found that `visitableWillAppear` is sometimes not called. So we can call it manually with this fix.

(related bugs: [one](https://stackoverflow.com/questions/131062/iphone-viewwillappear-not-firing) and [two](https://developer.apple.com/forums/thread/76834))