### PR TITLE
Cache project configuration

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,17 +1,14 @@
 import React from 'react';
-import {
-  NavigationContainer,
-  useNavigationContainerRef,
-} from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { default as NativeScreen } from './NumbersScreen';
 import ErrorScreen from './ErrorScreen';
-import { linking } from 'example/src/webScreen';
 import NestedTab from 'example/src/NestedTab';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { Routes } from 'example/src/webScreenRoutes';
 import ShareScreen from 'example/src/ShareScreen';
 import WebView from './WebView';
+import { WebScreenNavigation } from 'react-native-web-screen';
+import { baseURL, linkingConfig } from './webScreen';
 
 const Tab = createBottomTabNavigator();
 
@@ -40,10 +37,8 @@ const BottomTabs = () => {
 };
 
 const App: React.FC = () => {
-  const navigation = useNavigationContainerRef();
-
   return (
-    <NavigationContainer linking={linking} ref={navigation}>
+    <WebScreenNavigation baseURL={baseURL} linkingConfig={linkingConfig}>
       <Stack.Navigator
         screenOptions={{
           headerBackTitle: 'Back',
@@ -104,7 +99,7 @@ const App: React.FC = () => {
           options={{ title: 'Nested Top Tab' }}
         />
       </Stack.Navigator>
-    </NavigationContainer>
+    </WebScreenNavigation>
   );
 };
 

--- a/example/src/WebView.tsx
+++ b/example/src/WebView.tsx
@@ -9,7 +9,7 @@ import {
 import { useCurrentUrl, useWebviewNavigate } from 'react-native-web-screen';
 import { Routes } from './webScreenRoutes';
 import Form from './Strada/Form';
-import { RootStackParamList, baseURL, linkingConfig } from './webScreen';
+import { RootStackParamList } from './webScreen';
 import { NavigationProp } from '@react-navigation/native';
 
 export type Props = {
@@ -22,7 +22,7 @@ const stradaComponents = [Form];
 const WebView: React.FC<Props> = ({ navigation, ...props }) => {
   const navigateTo = useWebviewNavigate();
 
-  const currentUrl = useCurrentUrl(baseURL, linkingConfig);
+  const currentUrl = useCurrentUrl();
 
   const onVisitProposal = ({ action: actionType, url }: VisitProposal) => {
     navigateTo(url, actionType);

--- a/example/src/webScreen.ts
+++ b/example/src/webScreen.ts
@@ -1,4 +1,4 @@
-import { LinkingConfig, getLinkingObject } from 'react-native-web-screen';
+import { LinkingConfig } from 'react-native-web-screen';
 import { Routes } from './webScreenRoutes';
 
 export type RootStackParamList = {
@@ -28,5 +28,3 @@ export const linkingConfig: LinkingConfig = {
 };
 
 export const baseURL = 'http://localhost:45678/';
-
-export const linking = getLinkingObject(baseURL, linkingConfig);

--- a/packages/navigation/src/WebScreenNavigation.tsx
+++ b/packages/navigation/src/WebScreenNavigation.tsx
@@ -1,0 +1,33 @@
+import {
+  NavigationContainer,
+  useNavigationContainerRef,
+} from '@react-navigation/native';
+import React, { useMemo } from 'react';
+import { LinkingConfig } from './hooks/useCurrentUrl';
+import { getLinkingObject } from './buildWebScreen';
+
+interface Props {
+  linkingConfig: LinkingConfig;
+  baseURL: string;
+}
+
+const WebScreenNavigation: React.FC<Props> = ({
+  children,
+  linkingConfig,
+  baseURL,
+}) => {
+  const linking = useMemo(
+    () => getLinkingObject(baseURL, linkingConfig),
+    [baseURL, linkingConfig]
+  );
+
+  const navigation = useNavigationContainerRef();
+
+  return (
+    <NavigationContainer linking={linking} ref={navigation}>
+      {children}
+    </NavigationContainer>
+  );
+};
+
+export default WebScreenNavigation;

--- a/packages/navigation/src/WebScreenNavigation.tsx
+++ b/packages/navigation/src/WebScreenNavigation.tsx
@@ -2,16 +2,21 @@ import {
   NavigationContainer,
   useNavigationContainerRef,
 } from '@react-navigation/native';
-import React, { useMemo } from 'react';
+import React, { createContext, useMemo } from 'react';
 import { LinkingConfig } from './hooks/useCurrentUrl';
 import { getLinkingObject } from './buildWebScreen';
 
-interface Props {
+interface ConfigurationProps {
   linkingConfig: LinkingConfig;
   baseURL: string;
 }
 
-const WebScreenNavigation: React.FC<Props> = ({
+export const ConfigurationContext = createContext<ConfigurationProps>({
+  baseURL: '',
+  linkingConfig: { screens: {} },
+});
+
+const WebScreenNavigation: React.FC<ConfigurationProps> = ({
   children,
   linkingConfig,
   baseURL,
@@ -24,9 +29,11 @@ const WebScreenNavigation: React.FC<Props> = ({
   const navigation = useNavigationContainerRef();
 
   return (
-    <NavigationContainer linking={linking} ref={navigation}>
-      {children}
-    </NavigationContainer>
+    <ConfigurationContext.Provider value={{ baseURL, linkingConfig }}>
+      <NavigationContainer linking={linking} ref={navigation}>
+        {children}
+      </NavigationContainer>
+    </ConfigurationContext.Provider>
   );
 };
 

--- a/packages/navigation/src/buildWebScreen.tsx
+++ b/packages/navigation/src/buildWebScreen.tsx
@@ -29,20 +29,28 @@ function getParams(
   return undefined;
 }
 
+export function getWebScreenStateFromPath(
+  path: string,
+  options: Options,
+  baseURL: string
+) {
+  const state = getStateFromPath(path, options);
+  if (state) {
+    const params = getParams(unpackState(state)?.routes);
+    if (params) {
+      params.baseURL = baseURL;
+      params.fullPath = path;
+    }
+  }
+  return state;
+}
+
 export function getLinkingObject(baseURL: string, linking: LinkingConfig) {
   return {
     prefixes: [baseURL],
     config: linking,
     getStateFromPath(path: string, options?: Options) {
-      const state = getStateFromPath(path, options);
-      if (state) {
-        const params = getParams(unpackState(state)?.routes);
-        if (params) {
-          params.baseURL = baseURL;
-          params.fullPath = path;
-        }
-      }
-      return state;
+      return getWebScreenStateFromPath(path, options, baseURL);
     },
   };
 }

--- a/packages/navigation/src/hooks/useCurrentUrl.ts
+++ b/packages/navigation/src/hooks/useCurrentUrl.ts
@@ -1,4 +1,6 @@
 import { LinkingOptions, useNavigation } from '@react-navigation/native';
+import { ConfigurationContext } from '../WebScreenNavigation';
+import { useContext } from 'react';
 
 export type LinkingConfig = LinkingOptions<{}>['config'];
 
@@ -32,13 +34,17 @@ function getPath(params: unknown): string | undefined {
   return undefined;
 }
 
-export function useCurrentUrl(baseUrl: string, config: LinkingConfig) {
+export function useCurrentUrl() {
+  const { baseURL, linkingConfig } = useContext(ConfigurationContext);
+
   const navigation = useNavigation();
   const state = navigation.getState();
 
   const currentRoute = state.routes[state.index];
   const path =
-    getPath(currentRoute?.params) ?? findPath(currentRoute?.name, config) ?? '';
+    getPath(currentRoute?.params) ??
+    findPath(currentRoute?.name, linkingConfig) ??
+    '';
 
-  return new URL(path, baseUrl).toString();
+  return new URL(path, baseURL).toString();
 }

--- a/packages/navigation/src/index.tsx
+++ b/packages/navigation/src/index.tsx
@@ -1,3 +1,3 @@
 export { useWebviewNavigate } from './hooks/useWebviewNavigate';
 export { useCurrentUrl, LinkingConfig } from './hooks/useCurrentUrl';
-export * from './buildWebScreen';
+export { default as WebScreenNavigation } from './WebScreenNavigation';


### PR DESCRIPTION
Simplify how `useCurrentUrl`, `useWebviewNavigate` and project configuration works, by creating navigation wrapper.
This wrapper stores baseURL and linkingConfig - so it can be accessed in different places in app. It also removes need to manually configure linking in app.