### PR TITLE
Do not call viewWillAppear directly on a view controller

### DIFF
--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -49,9 +49,11 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
   
   override func willMove(toWindow newWindow: UIWindow?) {
+    super.willMove(toWindow: newWindow)
     // visitableWillAppear is not called automatically sometimes. So it has to be called
     // manually to make sure that visitableViews list is not empty
     // see https://github.com/software-mansion-labs/react-native-turbo-demo/pull/81
+    // and https://github.com/software-mansion-labs/react-native-turbo-demo/pull/86
     handleVisitableWillAppear()
   }
     


### PR DESCRIPTION
## Summary
This PR modifies the approach used in #81. Directly invoking `viewWillAppear` on a view controller is not supported, and may lead to out-of-order callbacks and other inconsistent behaviors.

