### PR TITLE
`getAction` doesn't work well with nested navigators

### DIFF
--- a/packages/navigation/src/hooks/useWebviewNavigate.ts
+++ b/packages/navigation/src/hooks/useWebviewNavigate.ts
@@ -57,8 +57,11 @@ function getAction(
   } else {
     const { name, params } = action.payload;
     const key =
-      (params && 'fullPath' in params && (params.fullPath as string)) ||
-      undefined;
+      (
+        params && 'params' in params && params.params &&
+        'fullPath' in params.params && (params.params.fullPath as string)
+      ) || undefined;
+    
     return CommonActions.navigate({
       name,
       key,


### PR DESCRIPTION
There seems to be an issue with nested navigators and the `useWebviewNavigate()`: in `getAction` a `key` is added to uniquely identify a screen to be pushed. This assumes that the `action.payload` is always a 'flat object`, eg:

```js
{
  "type": "NAVIGATE",
  "payload": {
     "name": "SomeScreen",
     "params": { .. }
  }
}
```

However, for nested navigators, the payload can look like this:

```js
{
  "type": "NAVIGATE",
  "payload": {
    "name": "FocusedFlow",
    "params": {
      "initial": true,
      "screen": "Subscription",
      "params": {
        "step": "checkout",
        "baseURL": "https://.../",
        "fullPath": "/subscribe/checkout"
      },
      "path": "/subscribe/checkout"
    }
  }
}
```

... in which case the `fullPath` will be tried extracted from the top-level object and not the `Subscription` screen in this case. We want to add the `key` and extract the `fullPath` in the deepest screen.