### PR TITLE
Add form submission callbacks and snapshot clearing method

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,7 +1,7 @@
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 require File.join(File.dirname(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")
 
-platform :ios, '12.4'
+platform :ios, '14.0'
 install! 'cocoapods', :deterministic_uuids => false
 
 target 'TurboWebviewExample' do
@@ -30,7 +30,7 @@ target 'TurboWebviewExample' do
     inherit! :complete
     # Pods for testing
   end
-  
+
   pod 'RNTurbo', :path => '../../packages/turbo'
 
   post_install do |installer|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -376,13 +376,13 @@ PODS:
     - React-jsi (= 0.70.13)
     - React-logger (= 0.70.13)
     - React-perflogger (= 0.70.13)
+  - ReactNativeHotwiredTurboiOS (7.0.1)
   - RNScreens (3.18.2):
     - React-Core
     - React-RCTImage
   - RNTurbo (0.2.4):
     - React-Core
-    - RNTurboiOS (= 7.0.0-beta.1)
-  - RNTurboiOS (7.0.0-beta.1)
+    - ReactNativeHotwiredTurboiOS (= 7.0.1)
   - SocketRocket (0.6.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -468,7 +468,7 @@ SPEC REPOS:
     - fmt
     - libevent
     - OpenSSL-Universal
-    - RNTurboiOS
+    - ReactNativeHotwiredTurboiOS
     - SocketRocket
     - YogaKit
 
@@ -599,13 +599,13 @@ SPEC CHECKSUMS:
   React-RCTVibration: 3b0e5f51cf2e6a1f8a7f36d50157bad0bfa4b984
   React-runtimeexecutor: 9ea931b43e2c2eb3c66ccdefcba8ff00cb523e09
   ReactCommon: a24276ab12f11099c91af00f7cf2c89d5f55313f
+  ReactNativeHotwiredTurboiOS: e6e8dd914b26db07487176c256e75c3ead5e7fb2
   RNScreens: 34cc502acf1b916c582c60003dc3089fa01dc66d
-  RNTurbo: 26bac3c0ab088899cceb9a1e03692d5246e3fce2
-  RNTurboiOS: 22091eb5d7be50050c694443a32a34b3069dd229
+  RNTurbo: bb86b9344e8d72206a4c482f5a2d5ab296566dbc
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 445485143df46a9d5d4ef61cbbc629fec40fb9a0
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 85b06d0ed137749e786ec852f3aa1ff84759e876
+PODFILE CHECKSUM: eb847012ad8e98e01a83cf4f002eb25e234cbe26
 
 COCOAPODS: 1.13.0

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -179,6 +179,20 @@ Note that after handling confirm dialog display, `callback` function must be cal
 - message
 - callback
 
+### `onFormSubmissionStarted`
+
+Callback called when website inside WebView started submitting form.
+
+- url
+
+### `onFormSubmissionFinished`
+
+Callback called when website inside WebView finished submitting form.
+
+- url
+
+Note: The form submission handlers are triggered for the _session_ in which the form was submitted. A URL argument is available in these handlers, which can be used for granular control over the cache clearing process. For example, you might choose to clear the cache only for the specific URL that the form was submitted from.
+
 ### Methods:
 
 ### `injectJavaScript(jsCode)`

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -27,6 +27,8 @@ For Android you need to adjust your SDK version in your `build.gradle`.
 >
 > Android SDK 24+ is required as the minSdkVersion in your build.gradle.
 
+For iOS, you need to set the deployment target to 14.0 or higher.
+
 ## Example
 
 Turbo `webview` can be rendered using native view `VisitableView`.
@@ -161,7 +163,7 @@ webkit.messageHandlers.nativeApp.postMessage(message);
 
 ### `onWebAlert`
 
-Function called when website inside WebView is calling `alert` function. By default React Native's `Alert` is displayed. 
+Function called when website inside WebView is calling `alert` function. By default React Native's `Alert` is displayed.
 
 Note that after handling alert display, `callback` function must be called.
 

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -197,6 +197,10 @@ injectJavaScript(jsCode);
 
 Reloads the webview.
 
+### `clearSnapshotCache`
+
+Clears the snapshot cache. It might be useful in a form submission scenario where different session handles are used for modals: when a form submission is completed in the modal session, we need to manually clear the snapshot cache in the default session to avoid using potentially outdated cached snapshots.
+
 ## Session Component
 
 Session component has been deprecated. To use multiple [sessions](https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#session), you can use `sessionHandle` prop on `VisitableView` component.

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -197,10 +197,12 @@ injectJavaScript(jsCode);
 
 Reloads the webview.
 
-### `clearSnapshotCache`
-
-Clears the snapshot cache. It might be useful in a form submission scenario where different session handles are used for modals: when a form submission is completed in the modal session, we need to manually clear the snapshot cache in the default session to avoid using potentially outdated cached snapshots.
-
 ## Session Component
 
 Session component has been deprecated. To use multiple [sessions](https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#session), you can use `sessionHandle` prop on `VisitableView` component.
+
+## Other utilities
+
+### `clearSnapshotCacheForAllSessions`
+
+Clears the snapshot cache for all sessions. This might be useful in a scenario where different session handles are used for modals. When a form submission is completed in the modal session, we need to manually clear the snapshot cache in the default session to avoid the use of potentially outdated cached snapshots.

--- a/packages/turbo/RNTurbo.podspec
+++ b/packages/turbo/RNTurbo.podspec
@@ -11,13 +11,13 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "12.0" }
+  s.platforms    = { :ios => "14.0" }
   s.source       = { :git => "https://github.com/software-mansion-labs/react-native-turbo-demo.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "RNTurboiOS", "7.0.0-beta.1"
+  s.dependency "ReactNativeHotwiredTurboiOS", "7.0.1"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -120,6 +120,11 @@ class RNSession(
     }
   }
 
+  fun clearSnapshotCache() {
+    // turbo-android doesn't expose a way to clear the snapshot cache, so we have to do it manually
+    webView.evaluateJavascript("window.Turbo.session.clearCache();", null)
+  }
+
   // region SessionCallbackAdapter
 
   override fun onReceivedError(errorCode: Int) {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -154,6 +154,14 @@ class RNSession(
     topmostView?.visitRendered()
   }
 
+  override fun formSubmissionStarted(location: String) {
+    topmostView?.didStartFormSubmission(location)
+  }
+
+  override fun formSubmissionFinished(location: String) {
+    topmostView?.didFinishFormSubmission(location)
+  }
+
   // end region
 
 }

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -122,7 +122,9 @@ class RNSession(
 
   fun clearSnapshotCache() {
     // turbo-android doesn't expose a way to clear the snapshot cache, so we have to do it manually
-    webView.evaluateJavascript("window.Turbo.session.clearCache();", null)
+    webView.post {
+      webView.evaluateJavascript("window.Turbo.session.clearCache();", null)
+    }
   }
 
   // region SessionCallbackAdapter

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionManager.kt
@@ -1,17 +1,36 @@
 package com.reactnativeturbowebview
 
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.module.annotations.ReactModule
 
-object RNSessionManager {
+private const val NAME = "RNSessionManager"
 
-  private val sessions: MutableMap<String, RNSession> = mutableMapOf()
+@ReactModule(name = NAME)
+class RNSessionManager(reactContext: ReactApplicationContext) :
+  ReactContextBaseJavaModule(reactContext) {
+  companion object {
+    private val sessions: MutableMap<String, RNSession> = mutableMapOf()
 
-  fun findOrCreateSession(
-    reactContext: ReactApplicationContext,
-    sessionHandle: String,
-    applicationNameForUserAgent: String? = null
-  ): RNSession = sessions.getOrPut(sessionHandle) {
-    RNSession(reactContext, sessionHandle, applicationNameForUserAgent)
+    fun findOrCreateSession(
+      reactContext: ReactApplicationContext,
+      sessionHandle: String,
+      applicationNameForUserAgent: String? = null
+    ): RNSession = sessions.getOrPut(sessionHandle) {
+      RNSession(reactContext, sessionHandle, applicationNameForUserAgent)
+    }
+
+    fun clearSnapshotCaches() {
+      sessions.values.forEach { it.clearSnapshotCache() }
+    }
+  }
+
+  override fun getName() = NAME
+
+  @ReactMethod
+  fun clearSnapshotCacheForAllSessions() {
+    clearSnapshotCaches()
   }
 
 }

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -345,10 +345,6 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     onConfirmHandler = null
   }
 
-  fun clearSnapshotCache() {
-    session.clearSnapshotCache()
-  }
-
   override fun requestFailedWithStatusCode(visitHasCachedSnapshot: Boolean, statusCode: Int) {
     sendEvent(RNVisitableViewEvent.VISIT_ERROR, Arguments.createMap().apply {
       putInt("statusCode", statusCode)

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -252,6 +252,18 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     })
   }
 
+  override fun didStartFormSubmission(url: String) {
+    sendEvent(RNVisitableViewEvent.FORM_SUBMISSION_START, Arguments.createMap().apply {
+      putString("url", url)
+    })
+  }
+
+  override fun didFinishFormSubmission(url: String) {
+    sendEvent(RNVisitableViewEvent.FORM_SUBMISSION_FINISH, Arguments.createMap().apply {
+      putString("url", url)
+    })
+  }
+
   override fun onReceivedError(errorCode: Int) {
     sendEvent(RNVisitableViewEvent.VISIT_ERROR, Arguments.createMap().apply {
       putInt("statusCode", errorCode)

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -253,13 +253,13 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun didStartFormSubmission(url: String) {
-    sendEvent(RNVisitableViewEvent.FORM_SUBMISSION_START, Arguments.createMap().apply {
+    sendEvent(RNVisitableViewEvent.FORM_SUBMISSION_STARTED, Arguments.createMap().apply {
       putString("url", url)
     })
   }
 
   override fun didFinishFormSubmission(url: String) {
-    sendEvent(RNVisitableViewEvent.FORM_SUBMISSION_FINISH, Arguments.createMap().apply {
+    sendEvent(RNVisitableViewEvent.FORM_SUBMISSION_FINISHED, Arguments.createMap().apply {
       putString("url", url)
     })
   }
@@ -272,14 +272,14 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun visitProposedToLocation(location: String, options: TurboVisitOptions) {
-    sendEvent(RNVisitableViewEvent.VISIT_PROPOSED, Arguments.createMap().apply {
+    sendEvent(RNVisitableViewEvent.VISIT_PROPOSAL, Arguments.createMap().apply {
       putString("url", location)
       putString("action", options.action.name.lowercase())
     })
   }
 
   override fun onRenderProcessGone() {
-    sendEvent(RNVisitableViewEvent.VISIT_PROPOSED, Arguments.createMap().apply {
+    sendEvent(RNVisitableViewEvent.VISIT_PROPOSAL, Arguments.createMap().apply {
       putString("url", url)
       putString("action", TurboVisitAction.REPLACE.name.lowercase())
     })
@@ -296,7 +296,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun visitRendered() {
-    sendEvent(RNVisitableViewEvent.PAGE_LOADED, Arguments.createMap().apply {
+    sendEvent(RNVisitableViewEvent.LOAD, Arguments.createMap().apply {
       putString("title", webView.title)
       putString("url", webView.url)
     })
@@ -304,7 +304,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun visitCompleted(completedOffline: Boolean) {
-    sendEvent(RNVisitableViewEvent.PAGE_LOADED, Arguments.createMap().apply {
+    sendEvent(RNVisitableViewEvent.LOAD, Arguments.createMap().apply {
       putString("title", webView.title)
       putString("url", webView.url)
     })
@@ -319,8 +319,8 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     }
   }
 
-  override fun handleAlert(message: String, callback: () -> Unit) {
-    sendEvent(RNVisitableViewEvent.ON_ALERT, Arguments.createMap().apply {
+  override fun handleAlert(message: String,callback: () -> Unit) {
+    sendEvent(RNVisitableViewEvent.WEB_ALERT, Arguments.createMap().apply {
       putString("message", message)
     })
     onAlertHandler = callback
@@ -328,7 +328,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
 
   override fun handleConfirm(message: String, callback: (result: Boolean) -> Unit) {
-    sendEvent(RNVisitableViewEvent.ON_CONFIRM, Arguments.createMap().apply {
+    sendEvent(RNVisitableViewEvent.WEB_CONFIRM, Arguments.createMap().apply {
       putString("message", message)
     })
     onConfirmHandler = callback

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -345,6 +345,10 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     onConfirmHandler = null
   }
 
+  fun clearSnapshotCache() {
+    session.clearSnapshotCache()
+  }
+
   override fun requestFailedWithStatusCode(visitHasCachedSnapshot: Boolean, statusCode: Int) {
     sendEvent(RNVisitableViewEvent.VISIT_ERROR, Arguments.createMap().apply {
       putInt("statusCode", statusCode)

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -13,12 +13,15 @@ enum class RNVisitableViewEvent(val jsCallbackName: String) {
   MESSAGE("onMessage"),
   OPEN_EXTERNAL_URL("onOpenExternalUrl"),
   ON_ALERT("onWebAlert"),
-  ON_CONFIRM("onWebConfirm")
+  ON_CONFIRM("onWebConfirm"),
+  FORM_SUBMISSION_START("onFormSubmissionStarted"),
+  FORM_SUBMISSION_FINISH("onFormSubmissionFinished")
 }
 
 enum class RNVisitableViewCommand(val jsCallbackName: String) {
   INJECT_JAVASCRIPT("injectJavaScript"),
   RELOAD_PAGE("reload"),
+  CLEAR_SNAPSHOT_CACHE("clearSnapshotCache"),
   SEND_ALERT_RESULT("sendAlertResult"),
   SEND_CONFIRM_RESULT("sendConfirmResult")
 }
@@ -66,6 +69,7 @@ class RNVisitableViewManager(
           root.sendConfirmResult(it)
         }
       }
+      RNVisitableViewCommand.CLEAR_SNAPSHOT_CACHE -> {}
     }
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -69,7 +69,7 @@ class RNVisitableViewManager(
           root.sendConfirmResult(it)
         }
       }
-      RNVisitableViewCommand.CLEAR_SNAPSHOT_CACHE -> {}
+      RNVisitableViewCommand.CLEAR_SNAPSHOT_CACHE -> root.clearSnapshotCache()
     }
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -7,15 +7,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 
 enum class RNVisitableViewEvent(val jsCallbackName: String) {
-  VISIT_PROPOSED("onVisitProposal"),
+  VISIT_PROPOSAL("onVisitProposal"),
   VISIT_ERROR("onVisitError"),
-  PAGE_LOADED("onLoad"),
+  LOAD("onLoad"),
   MESSAGE("onMessage"),
   OPEN_EXTERNAL_URL("onOpenExternalUrl"),
-  ON_ALERT("onWebAlert"),
-  ON_CONFIRM("onWebConfirm"),
-  FORM_SUBMISSION_START("onFormSubmissionStarted"),
-  FORM_SUBMISSION_FINISH("onFormSubmissionFinished")
+  WEB_ALERT("onWebAlert"),
+  WEB_CONFIRM("onWebConfirm"),
+  FORM_SUBMISSION_STARTED("onFormSubmissionStarted"),
+  FORM_SUBMISSION_FINISHED("onFormSubmissionFinished")
 }
 
 enum class RNVisitableViewCommand(val jsCallbackName: String) {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -21,7 +21,6 @@ enum class RNVisitableViewEvent(val jsCallbackName: String) {
 enum class RNVisitableViewCommand(val jsCallbackName: String) {
   INJECT_JAVASCRIPT("injectJavaScript"),
   RELOAD_PAGE("reload"),
-  CLEAR_SNAPSHOT_CACHE("clearSnapshotCache"),
   SEND_ALERT_RESULT("sendAlertResult"),
   SEND_CONFIRM_RESULT("sendConfirmResult")
 }
@@ -69,7 +68,6 @@ class RNVisitableViewManager(
           root.sendConfirmResult(it)
         }
       }
-      RNVisitableViewCommand.CLEAR_SNAPSHOT_CACHE -> root.clearSnapshotCache()
     }
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/ReactAppPackage.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/ReactAppPackage.kt
@@ -9,6 +9,7 @@ class ReactAppPackage : ReactPackage {
   override fun createViewManagers(reactContext: ReactApplicationContext) =
     listOf(RNVisitableViewManager(reactContext)).toMutableList()
 
-  override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> = mutableListOf()
+  override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> =
+    mutableListOf(RNSessionManager(reactContext))
 
 }

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/SessionSubscriber.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/SessionSubscriber.kt
@@ -7,6 +7,8 @@ interface SessionSubscriber: SessionCallbackAdapter {
   fun handleMessage(message: WritableMap)
   fun injectJavaScript(script: String)
   fun didOpenExternalUrl(url: String)
+  fun didStartFormSubmission(url: String)
+  fun didFinishFormSubmission(url: String)
   fun handleAlert(message: String, callback: () -> Unit)
   fun handleConfirm(message: String, callback: (result: Boolean) -> Unit)
 }

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -97,6 +97,10 @@ class RNSession: NSObject {
   func reload() {
     turboSession.reload()
   }
+    
+  func clearSnapshotCache() {
+    turboSession.clearSnapshotCache()
+  }
   
 }
 
@@ -117,6 +121,14 @@ extension RNSession: SessionDelegate {
 
   func session(_ session: Session, openExternalURL url: URL) {
     visitableViews.last?.didOpenExternalUrl(url: url)
+  }
+    
+  func sessionDidStartFormSubmission(_ session: Session) {
+    visitableViews.last?.didStartFormSubmission()
+  }
+    
+  func sessionDidFinishFormSubmission(_ session: Session) {
+    visitableViews.last?.didFinishFormSubmission()
   }
 }
 

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -5,7 +5,7 @@
 //  Created by Bartłomiej Fryz on 24/06/2022.
 //
 
-import RNTurboiOS
+import ReactNativeHotwiredTurboiOS
 import UIKit
 import WebKit
 

--- a/packages/turbo/ios/RNSessionManager.m
+++ b/packages/turbo/ios/RNSessionManager.m
@@ -1,0 +1,14 @@
+//
+//  RNSessionManager.m
+//  RNTurbo
+//
+//  Created by Patryk Klatka on 05/01/2024.
+//
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(RNSessionManager, NSObject)
+
+  RCT_EXTERN_METHOD(clearSnapshotCacheForAllSessions)
+
+@end

--- a/packages/turbo/ios/RNSessionManager.swift
+++ b/packages/turbo/ios/RNSessionManager.swift
@@ -7,13 +7,12 @@
 
 import Foundation
 
-class RNSessionManager {
+@objc(RNSessionManager)
+class RNSessionManager: NSObject {
 
   private var sessions: [NSString: RNSession] = [:]
   private var processPool = WKProcessPool()
   static var shared: RNSessionManager = RNSessionManager()
-
-  private init() {}
 
   func findOrCreateSession(sessionHandle: NSString, webViewConfiguration: WKWebViewConfiguration) -> RNSession {
     if(sessions[sessionHandle] == nil) {
@@ -21,6 +20,18 @@ class RNSessionManager {
       sessions[sessionHandle] = RNSession(sessionHandle: sessionHandle, webViewConfiguration: webViewConfiguration)
     }
     return sessions[sessionHandle]!
+  }
+    
+  @objc
+  func clearSnapshotCacheForAllSessions() {
+    for (sessionHandle, session) in sessions {
+      session.clearSnapshotCache()
+    }
+  }
+    
+  @objc
+  static func requiresMainQueueSetup() -> Bool {
+    return true
   }
 
 }

--- a/packages/turbo/ios/RNSessionManager.swift
+++ b/packages/turbo/ios/RNSessionManager.swift
@@ -22,11 +22,15 @@ class RNSessionManager: NSObject {
     return sessions[sessionHandle]!
   }
     
-  @objc
-  func clearSnapshotCacheForAllSessions() {
+  func clearSnapshotCaches() {
     for (sessionHandle, session) in sessions {
       session.clearSnapshotCache()
     }
+  }
+    
+  @objc
+  func clearSnapshotCacheForAllSessions() {
+    RNSessionManager.shared.clearSnapshotCaches()
   }
     
   @objc

--- a/packages/turbo/ios/RNSessionSubscriber.swift
+++ b/packages/turbo/ios/RNSessionSubscriber.swift
@@ -5,7 +5,7 @@
 //  Created by Bartłomiej Fryz on 23/01/2023.
 //
 
-import RNTurboiOS
+import ReactNativeHotwiredTurboiOS
 
 protocol RNSessionSubscriber {
   

--- a/packages/turbo/ios/RNSessionSubscriber.swift
+++ b/packages/turbo/ios/RNSessionSubscriber.swift
@@ -15,6 +15,8 @@ protocol RNSessionSubscriber {
   func didProposeVisit(proposal: VisitProposal)
   func didFailRequestForVisitable(visitable: Visitable, error: Error)
   func didOpenExternalUrl(url: URL)
+  func didStartFormSubmission()
+  func didFinishFormSubmission()
   func handleAlert(message: String, completionHandler: @escaping () -> Void)
   func handleConfirm(message: String, completionHandler: @escaping (Bool) -> Void)
 }

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -5,7 +5,7 @@
 //  Created by Bartłomiej Fryz on 24/06/2022.
 //
 
-import RNTurboiOS
+import ReactNativeHotwiredTurboiOS
 import UIKit
 
 class RNVisitableView: UIView, RNSessionSubscriber {

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -27,7 +27,9 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   @objc var onVisitError: RCTDirectEventBlock?
   @objc var onWebAlert: RCTDirectEventBlock?
   @objc var onWebConfirm: RCTDirectEventBlock?
-
+  @objc var onFormSubmissionStarted: RCTDirectEventBlock?
+  @objc var onFormSubmissionFinished: RCTDirectEventBlock?
+  
   private var onConfirmHandler: ((Bool) -> Void)?
   private var onAlertHandler: (() -> Void)?
 
@@ -127,6 +129,18 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     
   public func didOpenExternalUrl(url: URL) {
     onOpenExternalUrl?(["url": url.absoluteString])
+  }
+    
+  public func didStartFormSubmission() {
+    onFormSubmissionStarted?(["url": url])
+  }
+    
+  public func didFinishFormSubmission() {
+    onFormSubmissionFinished?(["url": url])
+  }
+    
+  func clearSessionSnapshotCache(){
+    session.clearSnapshotCache()
   }
 
   func handleAlert(message: String, completionHandler: @escaping () -> Void) {

--- a/packages/turbo/ios/RNVisitableViewController.swift
+++ b/packages/turbo/ios/RNVisitableViewController.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import RNTurboiOS
+import ReactNativeHotwiredTurboiOS
 
 public protocol RNVisitableViewControllerDelegate {
   

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -21,10 +21,13 @@
   RCT_EXPORT_VIEW_PROPERTY(onVisitError, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onWebAlert, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onWebConfirm, RCTDirectEventBlock)
+  RCT_EXPORT_VIEW_PROPERTY(onFormSubmissionStarted, RCTDirectEventBlock)
+  RCT_EXPORT_VIEW_PROPERTY(onFormSubmissionFinished, RCTDirectEventBlock)
 
   RCT_EXTERN_METHOD(injectJavaScript: (nonnull NSNumber) node
                     code: (nonnull NSString) code)
   RCT_EXTERN_METHOD(reload: (nonnull NSNumber) node)
+  RCT_EXTERN_METHOD(clearSnapshotCache: (nonnull NSNumber) node)
   RCT_EXTERN_METHOD(sendAlertResult: (nonnull NSNumber) node)
   RCT_EXTERN_METHOD(sendConfirmResult: (nonnull NSNumber) node
                     result: (nonnull NSString) code)

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -27,7 +27,6 @@
   RCT_EXTERN_METHOD(injectJavaScript: (nonnull NSNumber) node
                     code: (nonnull NSString) code)
   RCT_EXTERN_METHOD(reload: (nonnull NSNumber) node)
-  RCT_EXTERN_METHOD(clearSnapshotCache: (nonnull NSNumber) node)
   RCT_EXTERN_METHOD(sendAlertResult: (nonnull NSNumber) node)
   RCT_EXTERN_METHOD(sendConfirmResult: (nonnull NSNumber) node
                     result: (nonnull NSString) code)

--- a/packages/turbo/ios/RNVisitableViewManager.swift
+++ b/packages/turbo/ios/RNVisitableViewManager.swift
@@ -51,12 +51,5 @@ class RNVisitableViewManager: RCTViewManager {
     }
   }
     
-  @objc
-  func clearSnapshotCache(_ node: NSNumber) {
-    DispatchQueue.main.async {
-      let component = self.bridge.uiManager.view(forReactTag: node) as! RNVisitableView
-      component.clearSessionSnapshotCache()
-    }
-  }
 }
 

--- a/packages/turbo/ios/RNVisitableViewManager.swift
+++ b/packages/turbo/ios/RNVisitableViewManager.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import RNTurboiOS
+import ReactNativeHotwiredTurboiOS
 
 @objc(RNVisitableViewManager)
 class RNVisitableViewManager: RCTViewManager {

--- a/packages/turbo/ios/RNVisitableViewManager.swift
+++ b/packages/turbo/ios/RNVisitableViewManager.swift
@@ -50,5 +50,13 @@ class RNVisitableViewManager: RCTViewManager {
       component.sendConfirmResult(result: result)
     }
   }
+    
+  @objc
+  func clearSnapshotCache(_ node: NSNumber) {
+    DispatchQueue.main.async {
+      let component = self.bridge.uiManager.view(forReactTag: node) as! RNVisitableView
+      component.clearSessionSnapshotCache()
+    }
+  }
 }
 

--- a/packages/turbo/src/RNSessionManager.ts
+++ b/packages/turbo/src/RNSessionManager.ts
@@ -1,0 +1,11 @@
+import { NativeModules } from 'react-native';
+
+interface RNSessionManager {
+  clearSnapshotCacheForAllSessions(): void;
+}
+
+const { RNSessionManager } = NativeModules as {
+  RNSessionManager: RNSessionManager;
+};
+
+export const { clearSnapshotCacheForAllSessions } = RNSessionManager;

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -16,6 +16,7 @@ import type {
   VisitProposal,
   VisitProposalError,
   OpenExternalUrlEvent,
+  FormSubmissionEvent,
 } from './types';
 
 // interface should match RNVisitableView exported properties in native code
@@ -29,6 +30,12 @@ interface RNVisitableViewProps {
   onVisitProposal?: (e: NativeSyntheticEvent<VisitProposal>) => void;
   onWebAlert?: (e: NativeSyntheticEvent<AlertHandler>) => void;
   onWebConfirm?: (e: NativeSyntheticEvent<AlertHandler>) => void;
+  onFormSubmissionStarted?: (
+    e: NativeSyntheticEvent<FormSubmissionEvent>
+  ) => void;
+  onFormSubmissionFinished?: (
+    e: NativeSyntheticEvent<FormSubmissionEvent>
+  ) => void;
   style?: StyleProp<ViewStyle>;
 }
 
@@ -56,9 +63,17 @@ export function dispatchCommand(
     throw new Error(LINKING_ERROR);
   }
 
+  const transformedCommand = transformCommandToAcceptableType(
+    viewConfig.Commands[command]!
+  );
+
+  if (transformedCommand === undefined) {
+    return;
+  }
+
   UIManager.dispatchViewManagerCommand(
     findNodeHandle(ref.current),
-    transformCommandToAcceptableType(viewConfig.Commands[command]!),
+    transformedCommand,
     args
   );
 }

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -17,6 +17,7 @@ import type {
   VisitProposalError,
   OpenExternalUrlEvent,
   StradaComponent,
+  FormSubmissionEvent,
 } from './types';
 import { useStradaBridge } from './hooks/useStradaBridge';
 import { useMessageQueue } from './hooks/useMessageQueue';
@@ -34,6 +35,8 @@ export interface Props {
   onVisitProposal: (proposal: VisitProposal) => void;
   onLoad?: (params: LoadEvent) => void;
   onOpenExternalUrl?: (proposal: OpenExternalUrlEvent) => void;
+  onFormSubmissionStarted?: (e: FormSubmissionEvent) => void;
+  onFormSubmissionFinished?: (e: FormSubmissionEvent) => void;
   onVisitError?: OnErrorCallback;
   onMessage?: SessionMessageCallback;
   onAlert?: OnAlert;
@@ -42,6 +45,7 @@ export interface Props {
 
 export interface RefObject {
   injectJavaScript: (callbackStringified: string) => void;
+  clearSnapshotCache: () => void;
   reload: () => void;
 }
 
@@ -59,6 +63,8 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       onOpenExternalUrl: onOpenExternalUrlCallback = openExternalURL,
       onAlert,
       onConfirm,
+      onFormSubmissionStarted,
+      onFormSubmissionFinished,
     } = props;
     const visitableViewRef = useRef<typeof RNVisitableView>();
 
@@ -86,6 +92,8 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
             callbackStringified
           ),
         reload: () => dispatchCommand(visitableViewRef, 'reload'),
+        clearSnapshotCache: () =>
+          dispatchCommand(visitableViewRef, 'clearSnapshotCache'),
       }),
       []
     );
@@ -116,6 +124,20 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       ({ nativeEvent }: NativeSyntheticEvent<OpenExternalUrlEvent>) =>
         onOpenExternalUrlCallback(nativeEvent),
       [onOpenExternalUrlCallback]
+    );
+
+    const handleOnFormSubmissionStarted = useCallback(
+      ({ nativeEvent }: NativeSyntheticEvent<FormSubmissionEvent>) => {
+        onFormSubmissionStarted?.(nativeEvent);
+      },
+      [onFormSubmissionStarted]
+    );
+
+    const handleOnFormSubmissionFinished = useCallback(
+      ({ nativeEvent }: NativeSyntheticEvent<FormSubmissionEvent>) => {
+        onFormSubmissionFinished?.(nativeEvent);
+      },
+      [onFormSubmissionFinished]
     );
 
     const { handleAlert, handleConfirm } = useWebViewDialogs(
@@ -150,6 +172,8 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
           style={styles.container}
           onWebAlert={handleAlert}
           onWebConfirm={handleConfirm}
+          onFormSubmissionStarted={handleOnFormSubmissionStarted}
+          onFormSubmissionFinished={handleOnFormSubmissionFinished}
         />
       </>
     );

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -45,7 +45,6 @@ export interface Props {
 
 export interface RefObject {
   injectJavaScript: (callbackStringified: string) => void;
-  clearSnapshotCache: () => void;
   reload: () => void;
 }
 
@@ -92,8 +91,6 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
             callbackStringified
           ),
         reload: () => dispatchCommand(visitableViewRef, 'reload'),
-        clearSnapshotCache: () =>
-          dispatchCommand(visitableViewRef, 'clearSnapshotCache'),
       }),
       []
     );

--- a/packages/turbo/src/index.tsx
+++ b/packages/turbo/src/index.tsx
@@ -10,6 +10,8 @@ export {
   RefObject as VisitableViewRefObject,
 } from './VisitableView';
 
+export * from './RNSessionManager';
+
 export * from './BridgeComponent';
 
 export * from './types';

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -63,7 +63,6 @@ export type StradaMessages = {
 // list of methods available for RNVisitableView module
 export type DispatchCommandTypes =
   | 'injectJavaScript'
-  | 'clearSnapshotCache'
   | 'reload'
   | 'sendAlertResult'
   | 'sendConfirmResult';

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -14,6 +14,10 @@ export interface OpenExternalUrlEvent {
   url: string;
 }
 
+export interface FormSubmissionEvent {
+  url: string;
+}
+
 export type MessageEvent = object;
 
 export interface AlertHandler {
@@ -59,6 +63,7 @@ export type StradaMessages = {
 // list of methods available for RNVisitableView module
 export type DispatchCommandTypes =
   | 'injectJavaScript'
+  | 'clearSnapshotCache'
   | 'reload'
   | 'sendAlertResult'
   | 'sendConfirmResult';


### PR DESCRIPTION
This PR:
1. Bumps `turbo-ios` version to `7.0.1` by publishing new fork to CocoaPods repository. Previous fork didn't have form submission callbacks implemented in `SessionDelegate`.
2. Exposes `didStartFormSubmission` and `didFinishFormSubmission` callbacks on `VisitableView`.
3. Adds `clearSnapshotCache` method to `VisitableView` which clears snapshots on a session which `VisitableView` operates.