### PR TITLE
Support disabling 'pull-to-refresh' functionality

### DIFF
--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -84,6 +84,10 @@ Session handle for the webview. If not provided, the default session will be use
 
 The name of the application as used in the user agent string. Please note that changing this value after the session initialization will not change the user agent string.
 
+### `pullToRefreshEnabled`
+
+Enables pull to refresh functionality. Default value is `true`.
+
 ### `stradaComponents`
 
 `VisitableView` supports defining [Strada components](https://strada.hotwired.dev/) that receive and reply to messages from web components that are present on the page within one session. This prop accepts an array of Strada components that will be registered in the webview.

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -35,6 +35,11 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
   lateinit var sessionHandle: String
   var applicationNameForUserAgent: String? = null
+  var pullToRefreshEnabled: Boolean = true
+    set(value) {
+      field = value
+      setPullToRefresh(value)
+    }
 
   // Session
   private val session: RNSession by lazy {
@@ -228,7 +233,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     turboView.removeErrorView()
   }
 
-  private fun pullToRefreshEnabled(enabled: Boolean) {
+  private fun setPullToRefresh(enabled: Boolean) {
     turboView.webViewRefresh?.isEnabled = enabled
   }
 
@@ -287,12 +292,12 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
   override fun onZoomed(newScale: Float) {
     currentlyZoomed = true
-    pullToRefreshEnabled(false)
+    setPullToRefresh(false)
   }
 
   override fun onZoomReset(newScale: Float) {
     currentlyZoomed = false
-    pullToRefreshEnabled(true)
+    setPullToRefresh(pullToRefreshEnabled)
   }
 
   override fun visitRendered() {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -48,6 +48,12 @@ class RNVisitableViewManager(
     view.applicationNameForUserAgent = applicationNameForUserAgent
   }
 
+  @ReactProp(name = "pullToRefreshEnabled")
+  fun pullToRefreshEnabled(view: RNVisitableView, pullToRefreshEnabled: Boolean) {
+    view.pullToRefreshEnabled = pullToRefreshEnabled
+  }
+
+
   override fun getCommandsMap(): MutableMap<String, Int> = RNVisitableViewCommand.values()
     .associate {
       it.jsCallbackName to it.ordinal

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -20,6 +20,11 @@ class RNVisitableView: UIView, RNSessionSubscriber {
       }
     }
   }
+  @objc var pullToRefreshEnabled: Bool = true {
+    didSet {
+      controller.visitableView.allowsPullToRefresh = pullToRefreshEnabled
+    }
+  }
   @objc var onMessage: RCTDirectEventBlock?
   @objc var onVisitProposal: RCTDirectEventBlock?
   @objc var onOpenExternalUrl: RCTDirectEventBlock?

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -14,6 +14,7 @@
   RCT_EXPORT_VIEW_PROPERTY(url, NSString)
   RCT_EXPORT_VIEW_PROPERTY(sessionHandle, NSString)
   RCT_EXPORT_VIEW_PROPERTY(applicationNameForUserAgent, NSString)
+  RCT_EXPORT_VIEW_PROPERTY(pullToRefreshEnabled, BOOL)
   RCT_EXPORT_VIEW_PROPERTY(onVisitProposal, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onOpenExternalUrl, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -24,6 +24,7 @@ interface RNVisitableViewProps {
   url: string;
   sessionHandle?: string;
   applicationNameForUserAgent?: string;
+  pullToRefreshEnabled: boolean;
   onLoad?: (e: NativeSyntheticEvent<LoadEvent>) => void;
   onMessage?: (e: NativeSyntheticEvent<MessageEvent>) => void;
   onVisitError?: (e: NativeSyntheticEvent<VisitProposalError>) => void;

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -32,6 +32,7 @@ export interface Props {
   sessionHandle?: string;
   applicationNameForUserAgent?: string;
   stradaComponents?: StradaComponent[];
+  pullToRefreshEnabled?: boolean;
   onVisitProposal: (proposal: VisitProposal) => void;
   onLoad?: (params: LoadEvent) => void;
   onOpenExternalUrl?: (proposal: OpenExternalUrlEvent) => void;
@@ -64,6 +65,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       onConfirm,
       onFormSubmissionStarted,
       onFormSubmissionFinished,
+      pullToRefreshEnabled = true,
     } = props;
     const visitableViewRef = useRef<typeof RNVisitableView>();
 
@@ -161,6 +163,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
           url={props.url}
           sessionHandle={sessionHandle}
           applicationNameForUserAgent={resolvedApplicationNameForUserAgent}
+          pullToRefreshEnabled={pullToRefreshEnabled}
           onVisitProposal={handleVisitProposal}
           onMessage={handleOnMessage}
           onVisitError={handleVisitError}


### PR DESCRIPTION
## Summary

As stated in the title, this PR adds `pullToRefreshEnabled` prop which manages enabling 'pull-to-refresh' functionality.