### PR TITLE
Support onContentProcessDidTerminate callback

### DIFF
--- a/example/ios/TurboWebviewExample.xcodeproj/project.pbxproj
+++ b/example/ios/TurboWebviewExample.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		47F2550E2B4E9D4800FD3704 /* hermes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47F2550D2B4E9D4800FD3704 /* hermes.xcframework */; };
+		47F2550F2B4E9D4800FD3704 /* hermes.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 47F2550D2B4E9D4800FD3704 /* hermes.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7699B88040F8A987B510C191 /* libPods-TurboWebviewExample-TurboWebviewExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-TurboWebviewExample-TurboWebviewExampleTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -26,6 +28,20 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		47F255102B4E9D4800FD3704 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				47F2550F2B4E9D4800FD3704 /* hermes.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		00E356EE1AD99517003FC87E /* TurboWebviewExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurboWebviewExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -38,6 +54,7 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = TurboWebviewExample/main.m; sourceTree = "<group>"; };
 		19F6CBCC0A4E27FBF8BF4A61 /* libPods-TurboWebviewExample-TurboWebviewExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TurboWebviewExample-TurboWebviewExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-TurboWebviewExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TurboWebviewExample.debug.xcconfig"; path = "Target Support Files/Pods-TurboWebviewExample/Pods-TurboWebviewExample.debug.xcconfig"; sourceTree = "<group>"; };
+		47F2550D2B4E9D4800FD3704 /* hermes.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = hermes.xcframework; path = "Pods/hermes-engine/destroot/Library/Frameworks/universal/hermes.xcframework"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-TurboWebviewExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TurboWebviewExample.release.xcconfig"; path = "Target Support Files/Pods-TurboWebviewExample/Pods-TurboWebviewExample.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-TurboWebviewExample-TurboWebviewExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TurboWebviewExample-TurboWebviewExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-TurboWebviewExample-TurboWebviewExampleTests/Pods-TurboWebviewExample-TurboWebviewExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-TurboWebviewExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TurboWebviewExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -60,6 +77,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C80B921A6F3F58F76C31292 /* libPods-TurboWebviewExample.a in Frameworks */,
+				47F2550E2B4E9D4800FD3704 /* hermes.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,6 +117,7 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				47F2550D2B4E9D4800FD3704 /* hermes.xcframework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				5DCACB8F33CDC322A6C60F78 /* libPods-TurboWebviewExample.a */,
 				19F6CBCC0A4E27FBF8BF4A61 /* libPods-TurboWebviewExample-TurboWebviewExampleTests.a */,
@@ -184,6 +203,7 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */,
 				E235C05ADACE081382539298 /* [CP] Copy Pods Resources */,
+				47F255102B4E9D4800FD3704 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/example/ios/TurboWebviewExample.xcodeproj/project.pbxproj
+++ b/example/ios/TurboWebviewExample.xcodeproj/project.pbxproj
@@ -12,8 +12,6 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		47F2550E2B4E9D4800FD3704 /* hermes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 47F2550D2B4E9D4800FD3704 /* hermes.xcframework */; };
-		47F2550F2B4E9D4800FD3704 /* hermes.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 47F2550D2B4E9D4800FD3704 /* hermes.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7699B88040F8A987B510C191 /* libPods-TurboWebviewExample-TurboWebviewExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-TurboWebviewExample-TurboWebviewExampleTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -28,20 +26,6 @@
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		47F255102B4E9D4800FD3704 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				47F2550F2B4E9D4800FD3704 /* hermes.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		00E356EE1AD99517003FC87E /* TurboWebviewExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TurboWebviewExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -54,7 +38,6 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = TurboWebviewExample/main.m; sourceTree = "<group>"; };
 		19F6CBCC0A4E27FBF8BF4A61 /* libPods-TurboWebviewExample-TurboWebviewExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TurboWebviewExample-TurboWebviewExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-TurboWebviewExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TurboWebviewExample.debug.xcconfig"; path = "Target Support Files/Pods-TurboWebviewExample/Pods-TurboWebviewExample.debug.xcconfig"; sourceTree = "<group>"; };
-		47F2550D2B4E9D4800FD3704 /* hermes.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = hermes.xcframework; path = "Pods/hermes-engine/destroot/Library/Frameworks/universal/hermes.xcframework"; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-TurboWebviewExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TurboWebviewExample.release.xcconfig"; path = "Target Support Files/Pods-TurboWebviewExample/Pods-TurboWebviewExample.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-TurboWebviewExample-TurboWebviewExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TurboWebviewExample-TurboWebviewExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-TurboWebviewExample-TurboWebviewExampleTests/Pods-TurboWebviewExample-TurboWebviewExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-TurboWebviewExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TurboWebviewExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -77,7 +60,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C80B921A6F3F58F76C31292 /* libPods-TurboWebviewExample.a in Frameworks */,
-				47F2550E2B4E9D4800FD3704 /* hermes.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,7 +99,6 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				47F2550D2B4E9D4800FD3704 /* hermes.xcframework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				5DCACB8F33CDC322A6C60F78 /* libPods-TurboWebviewExample.a */,
 				19F6CBCC0A4E27FBF8BF4A61 /* libPods-TurboWebviewExample-TurboWebviewExampleTests.a */,
@@ -203,7 +184,6 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */,
 				E235C05ADACE081382539298 /* [CP] Copy Pods Resources */,
-				47F255102B4E9D4800FD3704 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -291,9 +291,8 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun onRenderProcessGone() {
-    sendEvent(RNVisitableViewEvent.VISIT_PROPOSAL, Arguments.createMap().apply {
+    sendEvent(RNVisitableViewEvent.CONTENT_PROCESS_DID_TERMINATE, Arguments.createMap().apply {
       putString("url", url)
-      putString("action", TurboVisitAction.REPLACE.name.lowercase())
     })
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -17,7 +17,8 @@ enum class RNVisitableViewEvent(val jsCallbackName: String) {
   FORM_SUBMISSION_STARTED("onFormSubmissionStarted"),
   FORM_SUBMISSION_FINISHED("onFormSubmissionFinished"),
   SHOW_LOADING("onShowLoading"),
-  HIDE_LOADING("onHideLoading")
+  HIDE_LOADING("onHideLoading"),
+  CONTENT_PROCESS_DID_TERMINATE("onContentProcessDidTerminate")
 }
 
 enum class RNVisitableViewCommand(val jsCallbackName: String) {

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -108,7 +108,7 @@ class RNSession: NSObject {
 extension RNSession: SessionDelegate {
   
   func sessionWebViewProcessDidTerminate(_ session: Session) {
-    
+    visitableViews.last?.processDidTerminate()
   }
 
   func session(_ session: Session, didProposeVisit proposal: VisitProposal) {

--- a/packages/turbo/ios/RNSessionSubscriber.swift
+++ b/packages/turbo/ios/RNSessionSubscriber.swift
@@ -17,6 +17,7 @@ protocol RNSessionSubscriber {
   func didOpenExternalUrl(url: URL)
   func didStartFormSubmission()
   func didFinishFormSubmission()
+  func processDidTerminate()
   func handleAlert(message: String, completionHandler: @escaping () -> Void)
   func handleConfirm(message: String, completionHandler: @escaping (Bool) -> Void)
 }

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -36,6 +36,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   @objc var onFormSubmissionFinished: RCTDirectEventBlock?
   @objc var onShowLoading: RCTDirectEventBlock?
   @objc var onHideLoading: RCTDirectEventBlock?
+  @objc var onContentProcessDidTerminate: RCTDirectEventBlock?
   
   private var onConfirmHandler: ((Bool) -> Void)?
   private var onAlertHandler: (() -> Void)?
@@ -149,6 +150,10 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     onFormSubmissionFinished?(["url": url])
   }
     
+  public func processDidTerminate() {
+    onContentProcessDidTerminate?(["url": url])
+  }
+
   func clearSessionSnapshotCache(){
     session.clearSnapshotCache()
   }

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -26,6 +26,7 @@
   RCT_EXPORT_VIEW_PROPERTY(onFormSubmissionFinished, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onShowLoading, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onHideLoading, RCTDirectEventBlock)
+  RCT_EXPORT_VIEW_PROPERTY(onContentProcessDidTerminate, RCTDirectEventBlock)
 
   RCT_EXTERN_METHOD(injectJavaScript: (nonnull NSNumber) node
                     code: (nonnull NSString) code)

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -17,6 +17,7 @@ import type {
   VisitProposalError,
   OpenExternalUrlEvent,
   FormSubmissionEvent,
+  ContentProcessDidTerminateEvent,
 } from './types';
 
 // interface should match RNVisitableView exported properties in native code
@@ -40,6 +41,9 @@ interface RNVisitableViewProps {
   ) => void;
   onShowLoading: () => void;
   onHideLoading: () => void;
+  onContentProcessDidTerminate?: (
+    e: NativeSyntheticEvent<ContentProcessDidTerminateEvent>
+  ) => void;
   style?: StyleProp<ViewStyle>;
 }
 

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -4,7 +4,7 @@ import React, {
   useRef,
   useMemo,
 } from 'react';
-import { NativeSyntheticEvent, StyleSheet, Platform } from 'react-native';
+import { NativeSyntheticEvent, StyleSheet } from 'react-native';
 import RNVisitableView, {
   dispatchCommand,
   openExternalURL,
@@ -71,10 +71,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       onFormSubmissionFinished,
       pullToRefreshEnabled = true,
       renderLoading,
-      onContentProcessDidTerminate = Platform.select({
-        ios: () => dispatchCommand(visitableViewRef, 'reload'),
-        android: () => onVisitProposal({ url, action: 'replace' }),
-      })!,
+      onContentProcessDidTerminate,
     } = props;
     const visitableViewRef = useRef<typeof RNVisitableView>();
 
@@ -161,6 +158,10 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       ({
         nativeEvent,
       }: NativeSyntheticEvent<ContentProcessDidTerminateEvent>) => {
+        if (!onContentProcessDidTerminate) {
+          dispatchCommand(visitableViewRef, 'reload');
+          return;
+        }
         onContentProcessDidTerminate(nativeEvent);
       },
       [onContentProcessDidTerminate]

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -18,6 +18,7 @@ import type {
   OpenExternalUrlEvent,
   StradaComponent,
   FormSubmissionEvent,
+  ContentProcessDidTerminateEvent,
 } from './types';
 import { useStradaBridge } from './hooks/useStradaBridge';
 import { useMessageQueue } from './hooks/useMessageQueue';
@@ -40,6 +41,7 @@ export interface Props {
   onOpenExternalUrl?: (proposal: OpenExternalUrlEvent) => void;
   onFormSubmissionStarted?: (e: FormSubmissionEvent) => void;
   onFormSubmissionFinished?: (e: FormSubmissionEvent) => void;
+  onContentProcessDidTerminate?: (e: ContentProcessDidTerminateEvent) => void;
   onVisitError?: OnErrorCallback;
   onMessage?: SessionMessageCallback;
   onAlert?: OnAlert;
@@ -69,6 +71,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       onFormSubmissionFinished,
       pullToRefreshEnabled = true,
       renderLoading,
+      onContentProcessDidTerminate,
     } = props;
     const visitableViewRef = useRef<typeof RNVisitableView>();
 
@@ -151,6 +154,19 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
     const { loadingComponent, handleShowLoading, handleHideLoading } =
       useRenderLoading(renderLoading);
 
+    const handleOnContentProcessDidTerminate = useCallback(
+      ({
+        nativeEvent,
+      }: NativeSyntheticEvent<ContentProcessDidTerminateEvent>) => {
+        if (!onContentProcessDidTerminate) {
+          dispatchCommand(visitableViewRef, 'reload');
+          return;
+        }
+        onContentProcessDidTerminate(nativeEvent);
+      },
+      [onContentProcessDidTerminate]
+    );
+
     return (
       <>
         {loadingComponent}
@@ -183,6 +199,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
           onFormSubmissionFinished={handleOnFormSubmissionFinished}
           onShowLoading={handleShowLoading}
           onHideLoading={handleHideLoading}
+          onContentProcessDidTerminate={handleOnContentProcessDidTerminate}
         />
       </>
     );

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -4,7 +4,7 @@ import React, {
   useRef,
   useMemo,
 } from 'react';
-import { NativeSyntheticEvent, StyleSheet } from 'react-native';
+import { NativeSyntheticEvent, StyleSheet, Platform } from 'react-native';
 import RNVisitableView, {
   dispatchCommand,
   openExternalURL,
@@ -71,7 +71,10 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       onFormSubmissionFinished,
       pullToRefreshEnabled = true,
       renderLoading,
-      onContentProcessDidTerminate,
+      onContentProcessDidTerminate = Platform.select({
+        ios: () => dispatchCommand(visitableViewRef, 'reload'),
+        android: () => onVisitProposal({ url, action: 'replace' }),
+      })!,
     } = props;
     const visitableViewRef = useRef<typeof RNVisitableView>();
 
@@ -158,10 +161,6 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       ({
         nativeEvent,
       }: NativeSyntheticEvent<ContentProcessDidTerminateEvent>) => {
-        if (!onContentProcessDidTerminate) {
-          dispatchCommand(visitableViewRef, 'reload');
-          return;
-        }
         onContentProcessDidTerminate(nativeEvent);
       },
       [onContentProcessDidTerminate]

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -18,6 +18,10 @@ export interface FormSubmissionEvent {
   url: string;
 }
 
+export interface ContentProcessDidTerminateEvent {
+  url: string;
+}
+
 export type MessageEvent = object;
 
 export interface AlertHandler {


### PR DESCRIPTION
## Summary

This PR implements `sessionWebViewProcessDidTerminate` callback on iOS and `onRenderProcessGone` on Android and exposes `onContentProcessDidTerminate`, which, by default, reloads webView (similarly to [turbo-ios approach](https://github.com/hotwired/turbo-ios/blob/f4decce15e85218397638b241665604f739e2ba1/Source/Turbo%20Navigator/TurboNavigator.swift#L128-L130))