### PR TITLE
PoC: Example to show alert that crashes app

### DIFF
--- a/example/server/views/layout.ejs
+++ b/example/server/views/layout.ejs
@@ -24,6 +24,12 @@
     <main id="content" class="grid pad --bottom-soft">
       <%- body %>
       
+      <script>
+        setTimeout(() => {
+          alert("Alert on page from <%= title %>")
+        }, 1000)
+      </script>
+
       <footer class="text --size-s --color-subtle space --top-xxl">
         Rendered <%- new Date() %>
 


### PR DESCRIPTION
This PR adds a PoC of #95.

To reproduce, navigate to the other tab ("Native Tab") *before* the alert is shown on the main tab:


https://github.com/software-mansion-labs/react-native-turbo-demo/assets/195925/3edcda2f-9939-4b95-9e51-898b26340daa

