### PR TITLE
Always call completion handler for alert/confirm dialog

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNWebChromeClient.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNWebChromeClient.kt
@@ -58,16 +58,25 @@ class RNWebChromeClient(
   override fun onJsAlert(
     view: WebView?, url: String?, message: String?, result: JsResult?
   ): Boolean {
-    visitableViews.lastOrNull()?.handleAlert(message ?: "") { result?.confirm() }
+    visitableViews.lastOrNull()?.let {
+      it.handleAlert(message ?: "") { result?.confirm() }
+    } ?: run {
+      result?.confirm()
+    }
+
     return true
   }
 
   override fun onJsConfirm(
     view: WebView?, url: String?, message: String?, result: JsResult?
   ): Boolean {
-    visitableViews.lastOrNull()?.handleConfirm(
-      message ?: ""
-    ) { confirmed -> if (confirmed) result?.confirm() else result?.cancel() }
+    visitableViews.lastOrNull()?.let {
+      it.handleConfirm(
+        message ?: ""
+      ) { confirmed -> if (confirmed) result?.confirm() else result?.cancel() }
+    } ?: run {
+      result?.cancel()
+    }
     return true
   }
 }

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -146,6 +146,7 @@ extension RNSession : WKUIDelegateHandler{
 
   func alertHandler(message: String, completionHandler: @escaping () -> Void) {
     guard let visitableView = visitableViews.last else {
+      completionHandler()
       return
     }
     visitableView.handleAlert(message: message, completionHandler: completionHandler)
@@ -153,6 +154,7 @@ extension RNSession : WKUIDelegateHandler{
 
   func confirmHandler(message: String, completionHandler: @escaping (Bool) -> Void) {
     guard let visitableView = visitableViews.last else {
+      completionHandler(false)
       return
     }
     visitableView.handleConfirm(message: message, completionHandler: completionHandler)


### PR DESCRIPTION
Fixes #95 

If `visitableView` was not present and we handled `alert`/`confirm` dialog from website -> callbacks methods were never called.
This RP fixes in on both platforms. On iOS this caused app crash (see #95). On Android it caused 'just webview' crash -> website was no longer visible after `alert` method was called.