### PR TITLE
Remove @ts-expect-error in RNVisitableView

### DIFF
--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -21,7 +21,7 @@ import type {
 } from './types';
 
 // interface should match RNVisitableView exported properties in native code
-interface RNVisitableViewProps {
+export interface RNVisitableViewProps {
   url: string;
   sessionHandle?: string;
   applicationNameForUserAgent?: string;

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -3,9 +3,11 @@ import React, {
   useImperativeHandle,
   useRef,
   useMemo,
+  Component,
 } from 'react';
-import { NativeSyntheticEvent, StyleSheet } from 'react-native';
+import { NativeMethods, NativeSyntheticEvent, StyleSheet } from 'react-native';
 import RNVisitableView, {
+  RNVisitableViewProps,
   dispatchCommand,
   openExternalURL,
 } from './RNVisitableView';
@@ -79,7 +81,9 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       onFormSubmissionFinished,
       onContentProcessDidTerminate,
     } = props;
-    const visitableViewRef = useRef<typeof RNVisitableView>();
+    const visitableViewRef = useRef<
+      Component<RNVisitableViewProps> & NativeMethods
+    >(null);
 
     const { registerMessageListener, handleOnMessage } =
       useMessageQueue(onMessage);
@@ -185,18 +189,17 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
     return (
       <>
         {webViewStateComponent}
-        {stradaComponents?.map((Component, i) => (
-          <Component
+        {stradaComponents?.map((StradaComponent, i) => (
+          <StradaComponent
             key={i}
             url={url}
             sessionHandle={sessionHandle}
-            name={Component.componentName}
+            name={StradaComponent.componentName}
             registerMessageListener={registerMessageListener}
             sendToBridge={sendToBridge}
           />
         ))}
         <RNVisitableView
-          // @ts-expect-error
           ref={visitableViewRef}
           url={props.url}
           sessionHandle={sessionHandle}


### PR DESCRIPTION
## Summary

Thanks to @tjzel, this PR removes `@ts-expect-error` from RNVisitableView.
