### PR TITLE
VisitableView: Remount Strada component when URL changes

### DIFF
--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -191,7 +191,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
         {webViewStateComponent}
         {stradaComponents?.map((StradaComponent, i) => (
           <StradaComponent
-            key={i}
+            key={`${url}-${i}`}
             url={url}
             sessionHandle={sessionHandle}
             name={StradaComponent.componentName}


### PR DESCRIPTION
This PR adds support for remounting Strada components as the URL is changed. This is important for screens that use `replace` where the params are updated (and via that the `url` prop), but the `VisitableView` stays the same.