### PR TITLE
iOS: Refactor and fix visitable delegates

### DIFF
--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -68,6 +68,10 @@ class RNSession: NSObject {
   }
   
   func visitableViewDidAppear(view: RNVisitableView) {
+    // if (visitableView !== nil && visitableView.isModal !== view.isModal) {
+    //   print("You're not able to share session between modal and non-modals.")
+    // }
+    
     self.visitableView = view
   }
   

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -93,12 +93,11 @@ class RNSession: NSObject {
   }
   
   func visitableViewWillAppear(view: RNSessionSubscriber) {
-    turboSession.visitableViewWillAppear(view.controller)
+    // No-op
   }
   
   func visitableViewDidAppear(view: RNSessionSubscriber) {
     registerVisitableView(newView: view)
-    turboSession.visitableViewDidAppear(view.controller)
   }
   
   func visit(_ visitable: Visitable) {
@@ -114,7 +113,6 @@ class RNSession: NSObject {
   }
   
 }
-
 
 extension RNSession: SessionDelegate {
   

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -179,17 +179,9 @@ class RNVisitableView: UIView, RNSessionSubscriber {
 }
 
 extension RNVisitableView: RNVisitableViewControllerDelegate {
-
-  func visitableWillAppear(visitable: Visitable) {
-    session.visitableViewWillAppear(view: self)
-  }
   
   func visitableDidAppear(visitable: Visitable) {
     session.visitableViewDidAppear(view: self)
-  }
-  
-  func visitableWillDisappear(visitable: Visitable) {
-    session.visitableViewWillDisappear(view: self)
   }
   
   func visitableDidDisappear(visitable: Visitable) {

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -14,8 +14,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   @objc var applicationNameForUserAgent: NSString? = nil
   @objc var url: NSString = "" {
     didSet {
-      let didSetAfterFirstVisit = oldValue != "" && url != oldValue
-      if(didSetAfterFirstVisit){
+      if(url != oldValue) {
         visit()
       }
     }
@@ -41,7 +40,6 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   private var onConfirmHandler: ((Bool) -> Void)?
   private var onAlertHandler: (() -> Void)?
 
-
   private lazy var session: RNSession = RNSessionManager.shared.findOrCreateSession(sessionHandle: sessionHandle!, webViewConfiguration: webViewConfiguration)
   private lazy var webView: WKWebView = session.webView
   private lazy var webViewConfiguration: WKWebViewConfiguration = {
@@ -56,7 +54,6 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     return controller
   }()
     
-  private var viewIsRegistered = false
   private var isRefreshing: Bool {
     controller.visitableView.isRefreshing
   }
@@ -68,15 +65,6 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     addSubview(controller.view)
   }
   
-  override func willMove(toWindow newWindow: UIWindow?) {
-    super.willMove(toWindow: newWindow)
-    // visitableWillAppear is not called automatically sometimes. So it has to be called
-    // manually to make sure that visitableViews list is not empty
-    // see https://github.com/software-mansion-labs/react-native-turbo-demo/pull/81
-    // and https://github.com/software-mansion-labs/react-native-turbo-demo/pull/86
-    handleVisitableWillAppear()
-  }
-    
   public func handleMessage(message: WKScriptMessage) {
     if let messageBody = message.body as? [AnyHashable : Any] {
       onMessage?(messageBody)
@@ -97,23 +85,23 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     self.onConfirmHandler?(confirmResult)
     self.onConfirmHandler = nil
   }
-    
+  
   public func reload(){
     session.reload()
   }
-    
+  
   private func visit() {
-    if(controller.visitableURL?.absoluteString == url as String) {
+    if (controller.visitableURL?.absoluteString == url as String) {
       return
     }
     performVisit()
   }
-    
+  
   private func performVisit() {
     controller.visitableURL = URL(string: String(url))
     session.visit(controller)
   }
-    
+  
   public func didProposeVisit(proposal: VisitProposal){
     if (webView.url == proposal.url) {
       // When reopening same URL we want to reload webview
@@ -126,7 +114,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
       onVisitProposal!(event)
     }
   }
-    
+  
   func getStatusCodeFromError(error: TurboError?) -> Int {
     switch error {
       case .networkFailure:
@@ -143,7 +131,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
         return -4
     }
   }
-
+  
   public func didFailRequestForVisitable(visitable: Visitable, error: Error){
     var event: [AnyHashable: Any] = [
       "url": visitable.visitableURL.absoluteString,
@@ -152,27 +140,27 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     ]
     onError?(event)
   }
-    
+  
   public func didOpenExternalUrl(url: URL) {
     onOpenExternalUrl?(["url": url.absoluteString])
   }
-    
+  
   public func didStartFormSubmission() {
     onFormSubmissionStarted?(["url": url])
   }
-    
+  
   public func didFinishFormSubmission() {
     onFormSubmissionFinished?(["url": url])
   }
-    
+  
   public func processDidTerminate() {
     onContentProcessDidTerminate?(["url": url])
   }
-
+  
   func clearSessionSnapshotCache(){
     session.clearSnapshotCache()
   }
-
+  
   func handleAlert(message: String, completionHandler: @escaping () -> Void) {
     let event: [AnyHashable: Any] = [
       "message": message,
@@ -188,28 +176,26 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     self.onWebConfirm?(event)
     self.onConfirmHandler = completionHandler
   }
-    
-  func handleVisitableWillAppear(){
-    if(viewIsRegistered){
-      return
-    }
-    session.registerVisitableView(newView: self)
-    viewIsRegistered = true
-    visit()
-  }
 }
 
 extension RNVisitableView: RNVisitableViewControllerDelegate {
-  
-  func visitableWillAppear(visitable: Visitable) {
-    handleVisitableWillAppear()
-  }
-    
-  func visitableDidDisappear(visitable: Visitable) {
-    session.unregisterVisitableView(view: self)
-    viewIsRegistered = false
-  }
 
+  func visitableWillAppear(visitable: Visitable) {
+    session.visitableViewWillAppear(view: self)
+  }
+  
+  func visitableDidAppear(visitable: Visitable) {
+    session.visitableViewDidAppear(view: self)
+  }
+  
+  func visitableWillDisappear(visitable: Visitable) {
+    session.visitableViewWillDisappear(view: self)
+  }
+  
+  func visitableDidDisappear(visitable: Visitable) {
+    session.visitableViewDidDisappear(view: self)
+  }
+  
   func visitableDidRender(visitable: Visitable) {
     let event: [AnyHashable: Any] = [
       "title": webView.title!,
@@ -217,12 +203,12 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
     ]
     onLoad?(event)
   }
-    
+  
   func showVisitableActivityIndicator() {
     guard !isRefreshing else { return }
     onShowLoading?([:])
   }
-      
+  
   func hideVisitableActivityIndicator() {
     onHideLoading?([:])
   }

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -57,6 +57,10 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   private var isRefreshing: Bool {
     controller.visitableView.isRefreshing
   }
+  
+  // var isModal: Bool {
+  //   return controller.reactViewController()?.isModal()
+  // }
     
   override func didMoveToWindow() {
     reactViewController()?.addChild(controller)

--- a/packages/turbo/ios/RNVisitableViewController.swift
+++ b/packages/turbo/ios/RNVisitableViewController.swift
@@ -12,12 +12,16 @@ public protocol RNVisitableViewControllerDelegate {
   
   func visitableWillAppear(visitable: Visitable)
   
+  func visitableDidAppear(visitable: Visitable)
+  
   func visitableDidRender(visitable: Visitable)
   
+  func visitableWillDisappear(visitable: Visitable)
+  
   func visitableDidDisappear(visitable: Visitable)
-    
+  
   func showVisitableActivityIndicator()
-    
+  
   func hideVisitableActivityIndicator()
   
 }
@@ -26,11 +30,14 @@ class RNVisitableViewController: VisitableViewController {
   
   public var delegate: RNVisitableViewControllerDelegate?
   
-  // For native stack this function is called fon every screen change
-  // as the view is replaced in the view hierarchy every time we navigate to a screen
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     delegate?.visitableWillAppear(visitable: self)
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    delegate?.visitableDidAppear(visitable: self)
   }
   
   override func visitableDidRender() {
@@ -38,15 +45,20 @@ class RNVisitableViewController: VisitableViewController {
     delegate?.visitableDidRender(visitable: self)
   }
   
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    delegate?.visitableWillDisappear(visitable: self)
+  }
+  
   override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
     delegate?.visitableDidDisappear(visitable: self)
   }
-    
+  
   override func showVisitableActivityIndicator(){
     delegate?.showVisitableActivityIndicator()
   }
-    
+  
   override func hideVisitableActivityIndicator(){
     delegate?.hideVisitableActivityIndicator()
   }

--- a/packages/turbo/ios/RNVisitableViewController.swift
+++ b/packages/turbo/ios/RNVisitableViewController.swift
@@ -10,13 +10,9 @@ import ReactNativeHotwiredTurboiOS
 
 public protocol RNVisitableViewControllerDelegate {
   
-  func visitableWillAppear(visitable: Visitable)
-  
   func visitableDidAppear(visitable: Visitable)
   
   func visitableDidRender(visitable: Visitable)
-  
-  func visitableWillDisappear(visitable: Visitable)
   
   func visitableDidDisappear(visitable: Visitable)
   
@@ -30,11 +26,6 @@ class RNVisitableViewController: VisitableViewController {
   
   public var delegate: RNVisitableViewControllerDelegate?
   
-  override func viewWillAppear(_ animated: Bool) {
-    super.viewWillAppear(animated)
-    delegate?.visitableWillAppear(visitable: self)
-  }
-  
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     delegate?.visitableDidAppear(visitable: self)
@@ -43,11 +34,6 @@ class RNVisitableViewController: VisitableViewController {
   override func visitableDidRender() {
     super.visitableDidRender()
     delegate?.visitableDidRender(visitable: self)
-  }
-  
-  override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
-    delegate?.visitableWillDisappear(visitable: self)
   }
   
   override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
This PR refactors the iOS delegates and addresses a few issues:

1. Previously, we had an array of all registered visitableViews in the session, primarily to support modals in the same session. This is not recommended/supported by Turbo iOS, so we can drop support for this, which simplifies the code quite a lot.
2. We did not notify the `TurboSession` via `viewWillAppear` previously; Turbo contains a few optimizations to complete navigations while a forward/back animation is in-flight, so calling this now fixes that
3. The `RNVisitableViewController` inherits from `VisitableViewController` which already has delegates for `visitableViewWillAppear` and calling that on the TurboSession. We remove the explicit call here to avoid double-calling it.