### PR TITLE
Fix dispatching confirm action before alert onPress action

### DIFF
--- a/packages/turbo/src/hooks/useWebViewDialogs.ts
+++ b/packages/turbo/src/hooks/useWebViewDialogs.ts
@@ -42,7 +42,6 @@ export function useWebViewDialogs(
           { text: 'OK', onPress: () => dispatch(true) },
           { text: 'Cancel', onPress: () => dispatch(false) },
         ]);
-        dispatch(true);
       }
     },
     [onConfirm, visitableViewRef]


### PR DESCRIPTION
## Summary
This PR removes `dispatch(true);` call which was causing to confirm the alert before `onPress` action.