### PR TITLE
Android: store only one instance of the VisitableView

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -153,11 +153,6 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     visit()
   }
 
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
-    session.removeVisitableView(this)
-  }
-
   private fun attachWebView(onReady: (Boolean) -> Unit) {
     // Sometimes detachWebView is not called before attachWebView.
     // This can happen when the user uses one session for different

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNWebChromeClient.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNWebChromeClient.kt
@@ -19,7 +19,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class RNWebChromeClient(
   private val reactContext: ReactApplicationContext,
-  private val visitableViews: LinkedHashSet<SessionSubscriber>
+  private val visitableView: SessionSubscriber?
 ) : ActivityEventListener, WebChromeClient() {
 
   private val fileChooserDelegate = RNFileChooserDelegate(reactContext)
@@ -34,7 +34,7 @@ class RNWebChromeClient(
     val result = view!!.hitTestResult
     val data = result.extra
     val uri = Uri.parse(data)
-    visitableViews.lastOrNull()?.didOpenExternalUrl(uri.toString())
+    visitableView?.didOpenExternalUrl(uri.toString())
     return false
   }
 
@@ -58,7 +58,7 @@ class RNWebChromeClient(
   override fun onJsAlert(
     view: WebView?, url: String?, message: String?, result: JsResult?
   ): Boolean {
-    visitableViews.lastOrNull()?.let {
+    visitableView?.let {
       it.handleAlert(message ?: "") { result?.confirm() }
     } ?: run {
       result?.confirm()
@@ -69,7 +69,7 @@ class RNWebChromeClient(
   override fun onJsConfirm(
     view: WebView?, url: String?, message: String?, result: JsResult?
   ): Boolean {
-    visitableViews.lastOrNull()?.let {
+    visitableView?.let {
       it.handleConfirm(
         message ?: ""
       ) { confirmed -> if (confirmed) result?.confirm() else result?.cancel() }


### PR DESCRIPTION
## Summary

This PR is a follow-up of #107 - to maintain similarities on both platforms we get rid of `visitableViews` list and change it to one `visitableView`.