### PR TITLE
Bugfix: Make `useCurrentUrl` work properly in top tab navigators

### DIFF
--- a/packages/navigation/src/hooks/useCurrentUrl.ts
+++ b/packages/navigation/src/hooks/useCurrentUrl.ts
@@ -1,4 +1,4 @@
-import { LinkingOptions, useNavigation } from '@react-navigation/native';
+import { LinkingOptions, useRoute } from '@react-navigation/native';
 
 export type LinkingConfig = LinkingOptions<{}>['config'];
 
@@ -33,10 +33,7 @@ function getPath(params: unknown): string | undefined {
 }
 
 export function useCurrentUrl(baseUrl: string, config: LinkingConfig) {
-  const navigation = useNavigation();
-  const state = navigation.getState();
-
-  const currentRoute = state.routes[state.index];
+  const currentRoute = useRoute();
   const path =
     getPath(currentRoute?.params) ?? findPath(currentRoute?.name, config) ?? '';
 


### PR DESCRIPTION
This PR fixes a bug where `useCurrentUrl` returned a wrong result if used in tab navigator, where multiple screens would be mounted at the same time (ie. `lazy: false` or if swiping between two screens).

Previously the route params etc. were extracted in a very manual manner using `useNavigation()` and based on the `state.index`. Since multiple screens in the tab navigator would be mounted at the same time, while the `state.index` is static (until actually navigating), we returned the URL from one screen (the one corresponding to `state.index`) for all screens.

The solution is to use the built-in hook `useRoute()` to return the route for a screen. 