### PR TITLE
iOS: Fix visitProposal being proposed before a visitableView is set

### DIFF
--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -67,12 +67,14 @@ class RNSession: NSObject {
     }
   }
   
+  func visitableViewWillAppear(view: RNVisitableView) {
+    self.visitableView = view
+  }
+  
   func visitableViewDidAppear(view: RNVisitableView) {
     // if (visitableView !== nil && visitableView.isModal !== view.isModal) {
     //   print("You're not able to share session between modal and non-modals.")
     // }
-    
-    self.visitableView = view
   }
   
   func visit(_ visitable: Visitable) {

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -184,6 +184,10 @@ class RNVisitableView: UIView, RNSessionSubscriber {
 
 extension RNVisitableView: RNVisitableViewControllerDelegate {
   
+  func visitableWillAppear(visitable: Visitable) {
+    session.visitableViewWillAppear(view: self)
+  }
+  
   func visitableDidAppear(visitable: Visitable) {
     session.visitableViewDidAppear(view: self)
   }

--- a/packages/turbo/ios/RNVisitableViewController.swift
+++ b/packages/turbo/ios/RNVisitableViewController.swift
@@ -10,6 +10,8 @@ import ReactNativeHotwiredTurboiOS
 
 public protocol RNVisitableViewControllerDelegate {
   
+  func viewWillAppear(visitable: Visitable)
+  
   func visitableDidAppear(visitable: Visitable)
   
   func visitableDidRender(visitable: Visitable)
@@ -25,6 +27,11 @@ public protocol RNVisitableViewControllerDelegate {
 class RNVisitableViewController: VisitableViewController {
   
   public var delegate: RNVisitableViewControllerDelegate?
+  
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    delegate?.visitableWillAppear(visitable: self)
+  }
   
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)

--- a/packages/turbo/ios/RNVisitableViewController.swift
+++ b/packages/turbo/ios/RNVisitableViewController.swift
@@ -10,7 +10,7 @@ import ReactNativeHotwiredTurboiOS
 
 public protocol RNVisitableViewControllerDelegate {
   
-  func viewWillAppear(visitable: Visitable)
+  func visitableWillAppear(visitable: Visitable)
   
   func visitableDidAppear(visitable: Visitable)
   


### PR DESCRIPTION
This PR fixes a "race condition" bug that happens when a visit is instantly proposed from a JavaScript visit (ie. the loaded page issues a `Turbo.visit(..)` on load.

In this case, the `visitableView` on the session would not be set before the new visit is proposed. This causes the proposal to be ignored, as there's no `visitableView` to notify.

Turbo iOS performs visit completion as part of the `..WillAppear(..)` flow, so this PR updates the place where we set the `visitableView` in `RNSession` to match that.