### PR TITLE
Refactor refresh/reload utilities

### DIFF
--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -252,14 +252,14 @@ Session component has been deprecated. To use multiple [sessions](https://github
 
 ## Other utilities
 
-### `getRegisteredSessionHandles`
+### `getSessionHandles`
 
 Returns an array of all registered session handles.
 
-### `reloadSessionByName`
+### `reloadSession`
 
 Reloads the webview for given `sessionHandle`.
 
-### `clearSessionSnapshotCacheByName`
+### `clearSessionSnapshotCache`
 
 Clears the snapshot cache for given `sessionHandle`. This might be useful in a scenario where different session handles are used for modals. When a form submission is completed in the modal session, we need to manually clear the snapshot cache in the default session to avoid the use of potentially outdated cached snapshots.

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -244,7 +244,11 @@ injectJavaScript(jsCode);
 
 ### `reload()`
 
-Reloads the webview.
+Reloads the webview. This method is equivalent to the WKWebView's `reload` method.
+
+### `refresh()`
+
+Refreshes the webview. This method is equivalent to making a turbo replace visit to the current URL.
 
 ## Session Component
 
@@ -252,14 +256,20 @@ Session component has been deprecated. To use multiple [sessions](https://github
 
 ## Other utilities
 
+Functions below might be useful in a scenario when a form submission is completed in the modal session - we need to manually clear the snapshot cache in the default session to avoid the use of potentially outdated cached snapshots.
+
 ### `getSessionHandles()`
 
 Returns an array of all registered session handles.
 
 ### `reloadSession(sessionHandle)`
 
-Reloads the webview for given `sessionHandle`.
+Reloads the webview for given `sessionHandle`. This method is equivalent to the WKWebView's `reload` method.
+
+### `refreshSession(sessionHandle)`
+
+Refreshes the webview for given `sessionHandle`. This method is equivalent to making a turbo replace visit to the current URL.
 
 ### `clearSessionSnapshotCache(sessionHandle)`
 
-Clears the snapshot cache for given `sessionHandle`. This might be useful in a scenario where different session handles are used for modals. When a form submission is completed in the modal session, we need to manually clear the snapshot cache in the default session to avoid the use of potentially outdated cached snapshots.
+Clears the snapshot cache for given `sessionHandle`.

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -252,14 +252,14 @@ Session component has been deprecated. To use multiple [sessions](https://github
 
 ## Other utilities
 
-### `getSessionHandles`
+### `getSessionHandles()`
 
 Returns an array of all registered session handles.
 
-### `reloadSession`
+### `reloadSession(sessionHandle)`
 
 Reloads the webview for given `sessionHandle`.
 
-### `clearSessionSnapshotCache`
+### `clearSessionSnapshotCache(sessionHandle)`
 
 Clears the snapshot cache for given `sessionHandle`. This might be useful in a scenario where different session handles are used for modals. When a form submission is completed in the modal session, we need to manually clear the snapshot cache in the default session to avoid the use of potentially outdated cached snapshots.

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -244,11 +244,11 @@ injectJavaScript(jsCode);
 
 ### `reload()`
 
-Reloads the webview. This method is equivalent to the WKWebView's `reload` method.
+Reloads the webview.
 
 ### `refresh()`
 
-Refreshes the webview. This method is equivalent to making a turbo replace visit to the current URL.
+Refreshes the page. This method is equivalent to making a Turbo `replace` visit to the current URL.
 
 ## Session Component
 
@@ -264,12 +264,12 @@ Returns an array of all registered session handles.
 
 ### `reloadSession(sessionHandle)`
 
-Reloads the webview for given `sessionHandle`. This method is equivalent to the WKWebView's `reload` method.
+Reloads the page for the given `sessionHandle`.
 
 ### `refreshSession(sessionHandle)`
 
-Refreshes the webview for given `sessionHandle`. This method is equivalent to making a turbo replace visit to the current URL.
+Refreshes the page for the given `sessionHandle`. This method is equivalent to making a Turbo `replace` visit to the current URL.
 
 ### `clearSessionSnapshotCache(sessionHandle)`
 
-Clears the snapshot cache for given `sessionHandle`.
+Clears the snapshot cache for the given `sessionHandle`.

--- a/packages/turbo/README.md
+++ b/packages/turbo/README.md
@@ -252,6 +252,14 @@ Session component has been deprecated. To use multiple [sessions](https://github
 
 ## Other utilities
 
-### `clearSnapshotCacheForAllSessions`
+### `getRegisteredSessionHandles`
 
-Clears the snapshot cache for all sessions. This might be useful in a scenario where different session handles are used for modals. When a form submission is completed in the modal session, we need to manually clear the snapshot cache in the default session to avoid the use of potentially outdated cached snapshots.
+Returns an array of all registered session handles.
+
+### `reloadSessionByName`
+
+Reloads the webview for given `sessionHandle`.
+
+### `clearSessionSnapshotCacheByName`
+
+Clears the snapshot cache for given `sessionHandle`. This might be useful in a scenario where different session handles are used for modals. When a form submission is completed in the modal session, we need to manually clear the snapshot cache in the default session to avoid the use of potentially outdated cached snapshots.

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -113,6 +113,12 @@ class RNSession(
 
   fun reload() {
     webView.post {
+      webView.reload()
+    }
+  }
+
+  fun refresh() {
+    webView.post {
       visitableView?.refresh(true)
     }
   }

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -119,7 +119,7 @@ class RNSession(
 
   fun refresh() {
     webView.post {
-      visitableView?.refresh(true)
+      visitableView?.refresh(false)
     }
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -111,6 +111,12 @@ class RNSession(
     }
   }
 
+  fun reload() {
+    webView.post {
+      visitableView?.refresh(true)
+    }
+  }
+
   fun clearSnapshotCache() {
     // turbo-android doesn't expose a way to clear the snapshot cache, so we have to do it manually
     webView.post {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -57,10 +57,10 @@ class RNSession(
     webView.settings.userAgentString = userAgentString
   }
 
-  fun visit(url: String, restoreWithCachedSnapshot: Boolean, reload: Boolean, viewTreeLifecycleOwner: LifecycleOwner?) {
+  fun visit(url: String, restoreWithCachedSnapshot: Boolean, reload: Boolean, viewTreeLifecycleOwner: LifecycleOwner?, visitOptions: TurboVisitOptions?){
     val restore = restoreWithCachedSnapshot && !reload
 
-    val options = when {
+    val options = visitOptions ?: when {
       restore -> TurboVisitOptions(action = TurboVisitAction.RESTORE)
       else -> TurboVisitOptions()
     }
@@ -113,13 +113,13 @@ class RNSession(
 
   fun reload() {
     webView.post {
-      webView.reload()
+      visitableView?.reload(true)
     }
   }
 
   fun refresh() {
     webView.post {
-      visitableView?.refresh(false)
+      visitableView?.refresh()
     }
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionManager.kt
@@ -1,8 +1,10 @@
 package com.reactnativeturbowebview
 
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.module.annotations.ReactModule
 
 private const val NAME = "RNSessionManager"
@@ -29,8 +31,34 @@ class RNSessionManager(reactContext: ReactApplicationContext) :
   override fun getName() = NAME
 
   @ReactMethod
-  fun clearSnapshotCacheForAllSessions() {
-    clearSnapshotCaches()
+  fun getRegisteredSessionHandles(promise: Promise) {
+    if(sessions.keys.isNotEmpty()) {
+      val sessionHandles = Arguments.createArray()
+      sessions.keys.forEach {
+        sessionHandles.pushString(it)
+      }
+      promise.resolve(sessionHandles)
+    }
+  }
+
+  @ReactMethod
+  fun reloadSessionByName(sessionHandle: String, promise: Promise) {
+    sessions[sessionHandle]?.let {
+      it.reload()
+      promise.resolve(null)
+    }  ?: run {
+      promise.reject("sessionHandle", "No session found with handle $sessionHandle")
+    }
+  }
+
+  @ReactMethod
+  fun clearSessionSnapshotCacheByName(sessionHandle: String, promise: Promise) {
+    sessions[sessionHandle]?.let {
+      it.clearSnapshotCache()
+      promise.resolve(null)
+    }  ?: run {
+      promise.reject("sessionHandle", "No session found with handle $sessionHandle")
+    }
   }
 
 }

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionManager.kt
@@ -31,7 +31,7 @@ class RNSessionManager(reactContext: ReactApplicationContext) :
   override fun getName() = NAME
 
   @ReactMethod
-  fun getRegisteredSessionHandles(promise: Promise) {
+  fun getSessionHandles(promise: Promise) {
     if(sessions.keys.isNotEmpty()) {
       val sessionHandles = Arguments.createArray()
       sessions.keys.forEach {
@@ -42,7 +42,7 @@ class RNSessionManager(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun reloadSessionByName(sessionHandle: String, promise: Promise) {
+  fun reloadSession(sessionHandle: String, promise: Promise) {
     sessions[sessionHandle]?.let {
       it.reload()
       promise.resolve(null)
@@ -52,7 +52,7 @@ class RNSessionManager(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun clearSessionSnapshotCacheByName(sessionHandle: String, promise: Promise) {
+  fun clearSessionSnapshotCache(sessionHandle: String, promise: Promise) {
     sessions[sessionHandle]?.let {
       it.clearSnapshotCache()
       promise.resolve(null)

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSessionManager.kt
@@ -52,6 +52,16 @@ class RNSessionManager(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
+  fun refreshSession(sessionHandle: String, promise: Promise) {
+    sessions[sessionHandle]?.let {
+      it.refresh()
+      promise.resolve(null)
+    }  ?: run {
+      promise.reject("sessionHandle", "No session found with handle $sessionHandle")
+    }
+  }
+
+  @ReactMethod
   fun clearSessionSnapshotCache(sessionHandle: String, promise: Promise) {
     sessions[sessionHandle]?.let {
       it.clearSnapshotCache()

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -63,7 +63,6 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   private var screenshotOrientation = 0
   private var screenshotZoomed = false
   private var screenshot: Bitmap? = null
-  private var hideActivityIndicatorOnNextLoad = false
 
   // Views
   private val visitableView = inflate(context, R.layout.turbo_view, null) as ViewGroup
@@ -113,7 +112,6 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun refresh() {
-    hideActivityIndicatorOnNextLoad = true
     session.visit(
       url = url,
       restoreWithCachedSnapshot = false,
@@ -234,10 +232,6 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   private fun showProgressView() {
     // Don't show the progress view if a screenshot is available
     if (screenshotView.isVisible) return
-    if (hideActivityIndicatorOnNextLoad) {
-      hideActivityIndicatorOnNextLoad = false
-      return;
-    }
     sendEvent(RNVisitableViewEvent.SHOW_LOADING, Arguments.createMap())
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -109,7 +109,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     }
   }
 
-  internal fun refresh(displayProgress: Boolean) {
+  override fun refresh(displayProgress: Boolean) {
     if (webView.url == null) return
 
     turboView.webViewRefresh?.apply {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -40,7 +40,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   var pullToRefreshEnabled: Boolean = true
     set(value) {
       field = value
-      setPullToReload(value)
+      setPullToRefresh(value)
     }
 
   // Session
@@ -74,8 +74,8 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     addView(visitableView)
 
     turboView.apply {
-      initializePullToReload(this)
-      initializeErrorPullToReload(this)
+      initializePullToRefresh(this)
+      initializeErrorPullToRefresh(this)
       showScreenshotIfAvailable(this)
       screenshot = null
       screenshotOrientation = 0
@@ -134,7 +134,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     performVisit(restoreWithCachedSnapshot = false, reload = true)
   }
 
-  private fun initializePullToReload(turboView: TurboView) {
+  private fun initializePullToRefresh(turboView: TurboView) {
     turboView.webViewRefresh?.apply {
       setOnRefreshListener {
         reload(displayProgress = true)
@@ -142,7 +142,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     }
   }
 
-  private fun initializeErrorPullToReload(turboView: TurboView) {
+  private fun initializeErrorPullToRefresh(turboView: TurboView) {
     turboView.errorRefresh?.apply {
       setOnRefreshListener {
         reload(displayProgress = true)
@@ -247,7 +247,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     turboView.removeErrorView()
   }
 
-  private fun setPullToReload(enabled: Boolean) {
+  private fun setPullToRefresh(enabled: Boolean) {
     turboView.webViewRefresh?.isEnabled = enabled
   }
 
@@ -306,12 +306,12 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
   override fun onZoomed(newScale: Float) {
     currentlyZoomed = true
-    setPullToReload(false)
+    setPullToRefresh(false)
   }
 
   override fun onZoomReset(newScale: Float) {
     currentlyZoomed = false
-    setPullToReload(pullToRefreshEnabled)
+    setPullToRefresh(pullToRefreshEnabled)
   }
 
   override fun visitRendered() {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -16,6 +16,7 @@ import dev.hotwire.turbo.views.TurboView
 import dev.hotwire.turbo.views.TurboWebView
 import dev.hotwire.turbo.visit.TurboVisitOptions
 import dev.hotwire.turbo.R
+import dev.hotwire.turbo.visit.TurboVisitAction
 
 class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscriber {
 
@@ -39,7 +40,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   var pullToRefreshEnabled: Boolean = true
     set(value) {
       field = value
-      setPullToRefresh(value)
+      setPullToReload(value)
     }
 
   // Session
@@ -73,8 +74,8 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     addView(visitableView)
 
     turboView.apply {
-      initializePullToRefresh(this)
-      initializeErrorPullToRefresh(this)
+      initializePullToReload(this)
+      initializeErrorPullToReload(this)
       showScreenshotIfAvailable(this)
       screenshot = null
       screenshotOrientation = 0
@@ -88,6 +89,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
       restoreWithCachedSnapshot = restoreWithCachedSnapshot,
       reload = reload,
       viewTreeLifecycleOwner = viewTreeLifecycleOwner,
+      visitOptions = null
     )
   }
 
@@ -109,11 +111,17 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     }
   }
 
-  fun reload() {
-    session.reload()
+  override fun refresh() {
+    session.visit(
+      url = url,
+      restoreWithCachedSnapshot = false,
+      reload = false,
+      viewTreeLifecycleOwner = viewTreeLifecycleOwner,
+      visitOptions = TurboVisitOptions(action = TurboVisitAction.REPLACE)
+    )
   }
 
-  override fun refresh(displayProgress: Boolean) {
+  override fun reload(displayProgress: Boolean) {
     if (webView.url == null) return
 
     turboView.webViewRefresh?.apply {
@@ -126,18 +134,18 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     performVisit(restoreWithCachedSnapshot = false, reload = true)
   }
 
-  private fun initializePullToRefresh(turboView: TurboView) {
+  private fun initializePullToReload(turboView: TurboView) {
     turboView.webViewRefresh?.apply {
       setOnRefreshListener {
-        refresh(displayProgress = true)
+        reload(displayProgress = true)
       }
     }
   }
 
-  private fun initializeErrorPullToRefresh(turboView: TurboView) {
+  private fun initializeErrorPullToReload(turboView: TurboView) {
     turboView.errorRefresh?.apply {
       setOnRefreshListener {
-        refresh(displayProgress = true)
+        reload(displayProgress = true)
       }
     }
   }
@@ -239,7 +247,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     turboView.removeErrorView()
   }
 
-  private fun setPullToRefresh(enabled: Boolean) {
+  private fun setPullToReload(enabled: Boolean) {
     turboView.webViewRefresh?.isEnabled = enabled
   }
 
@@ -298,12 +306,12 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
   override fun onZoomed(newScale: Float) {
     currentlyZoomed = true
-    setPullToRefresh(false)
+    setPullToReload(false)
   }
 
   override fun onZoomReset(newScale: Float) {
     currentlyZoomed = false
-    setPullToRefresh(pullToRefreshEnabled)
+    setPullToReload(pullToRefreshEnabled)
   }
 
   override fun visitRendered() {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -63,6 +63,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   private var screenshotOrientation = 0
   private var screenshotZoomed = false
   private var screenshot: Bitmap? = null
+  private var hideActivityIndicatorOnNextLoad = false
 
   // Views
   private val visitableView = inflate(context, R.layout.turbo_view, null) as ViewGroup
@@ -112,6 +113,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun refresh() {
+    hideActivityIndicatorOnNextLoad = true
     session.visit(
       url = url,
       restoreWithCachedSnapshot = false,
@@ -232,6 +234,10 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   private fun showProgressView() {
     // Don't show the progress view if a screenshot is available
     if (screenshotView.isVisible) return
+    if (hideActivityIndicatorOnNextLoad) {
+      hideActivityIndicatorOnNextLoad = false
+      return;
+    }
     sendEvent(RNVisitableViewEvent.SHOW_LOADING, Arguments.createMap())
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -109,6 +109,10 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     }
   }
 
+  fun reload() {
+    session.reload()
+  }
+
   override fun refresh(displayProgress: Boolean) {
     if (webView.url == null) return
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -72,7 +72,7 @@ class RNVisitableViewManager(
         }
       }
       RNVisitableViewCommand.RELOAD_PAGE -> root.reload()
-      RNVisitableViewCommand.REFRESH_PAGE -> root.refresh(true)
+      RNVisitableViewCommand.REFRESH_PAGE -> root.refresh(false)
       RNVisitableViewCommand.SEND_ALERT_RESULT -> root.sendAlertResult()
       RNVisitableViewCommand.SEND_CONFIRM_RESULT -> {
         args?.getString(0)?.let {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -71,8 +71,8 @@ class RNVisitableViewManager(
           root.injectJavaScript(it)
         }
       }
-      RNVisitableViewCommand.RELOAD_PAGE -> root.reload()
-      RNVisitableViewCommand.REFRESH_PAGE -> root.refresh(false)
+      RNVisitableViewCommand.RELOAD_PAGE -> root.reload(true)
+      RNVisitableViewCommand.REFRESH_PAGE -> root.refresh()
       RNVisitableViewCommand.SEND_ALERT_RESULT -> root.sendAlertResult()
       RNVisitableViewCommand.SEND_CONFIRM_RESULT -> {
         args?.getString(0)?.let {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -24,6 +24,7 @@ enum class RNVisitableViewEvent(val jsCallbackName: String) {
 enum class RNVisitableViewCommand(val jsCallbackName: String) {
   INJECT_JAVASCRIPT("injectJavaScript"),
   RELOAD_PAGE("reload"),
+  REFRESH_PAGE("refresh"),
   SEND_ALERT_RESULT("sendAlertResult"),
   SEND_CONFIRM_RESULT("sendConfirmResult")
 }
@@ -70,7 +71,8 @@ class RNVisitableViewManager(
           root.injectJavaScript(it)
         }
       }
-      RNVisitableViewCommand.RELOAD_PAGE -> root.refresh(true)
+      RNVisitableViewCommand.RELOAD_PAGE -> root.reload()
+      RNVisitableViewCommand.REFRESH_PAGE -> root.refresh(true)
       RNVisitableViewCommand.SEND_ALERT_RESULT -> root.sendAlertResult()
       RNVisitableViewCommand.SEND_CONFIRM_RESULT -> {
         args?.getString(0)?.let {

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/SessionSubscriber.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/SessionSubscriber.kt
@@ -11,5 +11,6 @@ interface SessionSubscriber: SessionCallbackAdapter {
   fun didFinishFormSubmission(url: String)
   fun handleAlert(message: String, callback: () -> Unit)
   fun handleConfirm(message: String, callback: (result: Boolean) -> Unit)
-  fun refresh(displayProgress: Boolean)
+  fun reload(displayProgress: Boolean)
+  fun refresh()
 }

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/SessionSubscriber.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/SessionSubscriber.kt
@@ -11,4 +11,5 @@ interface SessionSubscriber: SessionCallbackAdapter {
   fun didFinishFormSubmission(url: String)
   fun handleAlert(message: String, callback: () -> Unit)
   fun handleConfirm(message: String, callback: (result: Boolean) -> Unit)
+  fun refresh(displayProgress: Boolean)
 }

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -80,8 +80,12 @@ class RNSession: NSObject {
   func visit(_ visitable: Visitable) {
     turboSession.visit(visitable)
   }
-  
+    
   func reload() {
+    webView.reload()
+  }
+  
+  func refresh() {
     turboSession.reload()
   }
   

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -81,12 +81,16 @@ class RNSession: NSObject {
     turboSession.visit(visitable)
   }
     
+  func visit(_ visitable: Visitable, action: VisitAction) {
+    turboSession.visit(visitable, action: action)
+  }
+    
   func reload() {
-    webView.reload()
+    turboSession.reload()
   }
   
   func refresh() {
-    turboSession.reload()
+    visitableView?.refresh()
   }
   
   func clearSnapshotCache() {

--- a/packages/turbo/ios/RNSessionManager.m
+++ b/packages/turbo/ios/RNSessionManager.m
@@ -9,12 +9,12 @@
 
 @interface RCT_EXTERN_MODULE(RNSessionManager, NSObject)
 
-  RCT_EXTERN_METHOD(getRegisteredSessionHandles: (RCTPromiseResolveBlock) resolve
+  RCT_EXTERN_METHOD(getSessionHandles: (RCTPromiseResolveBlock) resolve
                     rejecter: (RCTPromiseRejectBlock) reject)
-  RCT_EXTERN_METHOD(reloadSessionByName: (nonnull NSString) sessionHandle
+  RCT_EXTERN_METHOD(reloadSession: (nonnull NSString) sessionHandle
                     resolver: (RCTPromiseResolveBlock) resolve
                     rejecter: (RCTPromiseRejectBlock) reject)
-  RCT_EXTERN_METHOD(clearSessionSnapshotCacheByName: (nonnull NSString) sessionHandle
+  RCT_EXTERN_METHOD(clearSessionSnapshotCache: (nonnull NSString) sessionHandle
                     resolver: (RCTPromiseResolveBlock) resolve
                     rejecter: (RCTPromiseRejectBlock) reject)
 

--- a/packages/turbo/ios/RNSessionManager.m
+++ b/packages/turbo/ios/RNSessionManager.m
@@ -14,6 +14,9 @@
   RCT_EXTERN_METHOD(reloadSession: (nonnull NSString) sessionHandle
                     resolver: (RCTPromiseResolveBlock) resolve
                     rejecter: (RCTPromiseRejectBlock) reject)
+  RCT_EXTERN_METHOD(refreshSession: (nonnull NSString) sessionHandle
+                    resolver: (RCTPromiseResolveBlock) resolve
+                    rejecter: (RCTPromiseRejectBlock) reject)
   RCT_EXTERN_METHOD(clearSessionSnapshotCache: (nonnull NSString) sessionHandle
                     resolver: (RCTPromiseResolveBlock) resolve
                     rejecter: (RCTPromiseRejectBlock) reject)

--- a/packages/turbo/ios/RNSessionManager.m
+++ b/packages/turbo/ios/RNSessionManager.m
@@ -9,6 +9,13 @@
 
 @interface RCT_EXTERN_MODULE(RNSessionManager, NSObject)
 
-  RCT_EXTERN_METHOD(clearSnapshotCacheForAllSessions)
+  RCT_EXTERN_METHOD(getRegisteredSessionHandles: (RCTPromiseResolveBlock) resolve
+                    rejecter: (RCTPromiseRejectBlock) reject)
+  RCT_EXTERN_METHOD(reloadSessionByName: (nonnull NSString) sessionHandle
+                    resolver: (RCTPromiseResolveBlock) resolve
+                    rejecter: (RCTPromiseRejectBlock) reject)
+  RCT_EXTERN_METHOD(clearSessionSnapshotCacheByName: (nonnull NSString) sessionHandle
+                    resolver: (RCTPromiseResolveBlock) resolve
+                    rejecter: (RCTPromiseRejectBlock) reject)
 
 @end

--- a/packages/turbo/ios/RNSessionManager.swift
+++ b/packages/turbo/ios/RNSessionManager.swift
@@ -30,7 +30,7 @@ class RNSessionManager: NSObject {
   @objc
   func reloadSessionByName(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     guard let session = RNSessionManager.shared.sessions[sessionHandle] else {
-      reject("sessionHandle", "Session with this handle does not exist", nil)
+      reject("sessionHandle", "No session found with handle \(sessionHandle)", nil)
       return
     }
     DispatchQueue.main.async {
@@ -42,7 +42,7 @@ class RNSessionManager: NSObject {
   @objc
   func clearSessionSnapshotCacheByName(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     guard let session = RNSessionManager.shared.sessions[sessionHandle] else {
-      reject("sessionHandle", "Session with this handle does not exist", nil)
+      reject("sessionHandle", "No session found with handle \(sessionHandle)", nil)
       return
     }
     DispatchQueue.main.async {

--- a/packages/turbo/ios/RNSessionManager.swift
+++ b/packages/turbo/ios/RNSessionManager.swift
@@ -38,6 +38,18 @@ class RNSessionManager: NSObject {
       resolve(nil)
     }
   }
+    
+  @objc
+  func refreshSession(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    guard let session = RNSessionManager.shared.sessions[sessionHandle] else {
+      reject("sessionHandle", "No session found with handle \(sessionHandle)", nil)
+      return
+    }
+    DispatchQueue.main.async {
+      session.refresh()
+      resolve(nil)
+    }
+  }
    
   @objc
   func clearSessionSnapshotCache(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {

--- a/packages/turbo/ios/RNSessionManager.swift
+++ b/packages/turbo/ios/RNSessionManager.swift
@@ -23,12 +23,12 @@ class RNSessionManager: NSObject {
   }
     
   @objc
-  func getRegisteredSessionHandles(_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock){
+  func getSessionHandles(_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock){
     resolve(Array(RNSessionManager.shared.sessions.keys))
   }
     
   @objc
-  func reloadSessionByName(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+  func reloadSession(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     guard let session = RNSessionManager.shared.sessions[sessionHandle] else {
       reject("sessionHandle", "No session found with handle \(sessionHandle)", nil)
       return
@@ -40,7 +40,7 @@ class RNSessionManager: NSObject {
   }
    
   @objc
-  func clearSessionSnapshotCacheByName(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+  func clearSessionSnapshotCache(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     guard let session = RNSessionManager.shared.sessions[sessionHandle] else {
       reject("sessionHandle", "No session found with handle \(sessionHandle)", nil)
       return

--- a/packages/turbo/ios/RNSessionManager.swift
+++ b/packages/turbo/ios/RNSessionManager.swift
@@ -22,15 +22,33 @@ class RNSessionManager: NSObject {
     return sessions[sessionHandle]!
   }
     
-  func clearSnapshotCaches() {
-    for (sessionHandle, session) in sessions {
-      session.clearSnapshotCache()
-    }
+  @objc
+  func getRegisteredSessionHandles(_ resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock){
+    resolve(Array(RNSessionManager.shared.sessions.keys))
   }
     
   @objc
-  func clearSnapshotCacheForAllSessions() {
-    RNSessionManager.shared.clearSnapshotCaches()
+  func reloadSessionByName(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    guard let session = RNSessionManager.shared.sessions[sessionHandle] else {
+      reject("sessionHandle", "Session with this handle does not exist", nil)
+      return
+    }
+    DispatchQueue.main.async {
+      session.reload()
+      resolve(nil)
+    }
+  }
+   
+  @objc
+  func clearSessionSnapshotCacheByName(_ sessionHandle: NSString, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+    guard let session = RNSessionManager.shared.sessions[sessionHandle] else {
+      reject("sessionHandle", "Session with this handle does not exist", nil)
+      return
+    }
+    DispatchQueue.main.async {
+      session.clearSnapshotCache()
+      resolve(nil)
+    }
   }
     
   @objc

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -36,7 +36,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   @objc var onShowLoading: RCTDirectEventBlock?
   @objc var onHideLoading: RCTDirectEventBlock?
   @objc var onContentProcessDidTerminate: RCTDirectEventBlock?
-  
+
   private var onConfirmHandler: ((Bool) -> Void)?
   private var onAlertHandler: (() -> Void)?
 
@@ -47,69 +47,73 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     configuration.applicationNameForUserAgent = applicationNameForUserAgent as String?
     return configuration
   }()
-    
+
   lazy var controller: RNVisitableViewController = {
     let controller = RNVisitableViewController()
     controller.delegate = self
     return controller
   }()
-    
+
   private var isRefreshing: Bool {
     controller.visitableView.isRefreshing
   }
-  
+
   // var isModal: Bool {
   //   return controller.reactViewController()?.isModal()
   // }
-    
+
   override func didMoveToWindow() {
     reactViewController()?.addChild(controller)
     controller.view.frame = bounds // Fixes incorrect size of the webview
     controller.didMove(toParent: reactViewController())
     addSubview(controller.view)
   }
-  
+
   public func handleMessage(message: WKScriptMessage) {
     if let messageBody = message.body as? [AnyHashable : Any] {
       onMessage?(messageBody)
     }
   }
-  
+
   public func injectJavaScript(code: NSString) -> Void {
     webView.evaluateJavaScript(code as String)
   }
-  
+
   public func sendAlertResult() -> Void {
     self.onAlertHandler?()
     self.onAlertHandler = nil
   }
-  
+
   public func sendConfirmResult(result: NSString) -> Void {
     let confirmResult = result == "true"
     self.onConfirmHandler?(confirmResult)
     self.onConfirmHandler = nil
   }
-  
+
   public func reload(){
     session.reload()
   }
-  
+
+  public func refresh(){
+    session.refresh()
+  }
+
   private func visit() {
     if (controller.visitableURL?.absoluteString == url as String) {
       return
     }
     performVisit()
   }
-  
+
   private func performVisit() {
     controller.visitableURL = URL(string: String(url))
     session.visit(controller)
   }
-  
+
   public func didProposeVisit(proposal: VisitProposal){
-    if (webView.url == proposal.url) {
-      // When reopening same URL we want to reload webview
-      reload()
+    if (webView.url == proposal.url && proposal.options.action == .replace) {
+      // When reopening same URL we want to refresh webview
+      refresh()
     } else {
       let event: [AnyHashable: Any] = [
         "url": proposal.url.absoluteString,
@@ -118,7 +122,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
       onVisitProposal!(event)
     }
   }
-  
+
   func getStatusCodeFromError(error: TurboError?) -> Int {
     switch error {
       case .networkFailure:
@@ -135,7 +139,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
         return -4
     }
   }
-  
+
   public func didFailRequestForVisitable(visitable: Visitable, error: Error){
     var event: [AnyHashable: Any] = [
       "url": visitable.visitableURL.absoluteString,
@@ -144,27 +148,27 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     ]
     onError?(event)
   }
-  
+
   public func didOpenExternalUrl(url: URL) {
     onOpenExternalUrl?(["url": url.absoluteString])
   }
-  
+
   public func didStartFormSubmission() {
     onFormSubmissionStarted?(["url": url])
   }
-  
+
   public func didFinishFormSubmission() {
     onFormSubmissionFinished?(["url": url])
   }
-  
+
   public func processDidTerminate() {
     onContentProcessDidTerminate?(["url": url])
   }
-  
+
   func clearSessionSnapshotCache(){
     session.clearSnapshotCache()
   }
-  
+
   func handleAlert(message: String, completionHandler: @escaping () -> Void) {
     let event: [AnyHashable: Any] = [
       "message": message,
@@ -172,7 +176,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     self.onWebAlert?(event)
     self.onAlertHandler = completionHandler
   }
-  
+
   func handleConfirm(message: String, completionHandler: @escaping (Bool) -> Void) {
     let event: [AnyHashable: Any] = [
       "message": message,
@@ -183,19 +187,19 @@ class RNVisitableView: UIView, RNSessionSubscriber {
 }
 
 extension RNVisitableView: RNVisitableViewControllerDelegate {
-  
+
   func visitableWillAppear(visitable: Visitable) {
     session.visitableViewWillAppear(view: self)
   }
-  
+
   func visitableDidAppear(visitable: Visitable) {
     session.visitableViewDidAppear(view: self)
   }
-  
+
   func visitableDidDisappear(visitable: Visitable) {
     session.visitableViewDidDisappear(view: self)
   }
-  
+
   func visitableDidRender(visitable: Visitable) {
     let event: [AnyHashable: Any] = [
       "title": webView.title!,
@@ -203,14 +207,14 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
     ]
     onLoad?(event)
   }
-  
+
   func showVisitableActivityIndicator() {
     guard !isRefreshing else { return }
     onShowLoading?([:])
   }
-  
+
   func hideVisitableActivityIndicator() {
     onHideLoading?([:])
   }
-  
+
 }

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -90,12 +90,12 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     self.onConfirmHandler = nil
   }
 
-  public func reload(){
+  public func reload() {
     session.reload()
   }
 
-  public func refresh(){
-    session.refresh()
+  public func refresh() {
+    session.visit(controller, action: .replace)
   }
 
   private func visit() {

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -57,8 +57,6 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   private var isRefreshing: Bool {
     controller.visitableView.isRefreshing
   }
-    
-  private var hideActivityIndicatorOnNextLoad = false
 
   // var isModal: Bool {
   //   return controller.reactViewController()?.isModal()
@@ -97,7 +95,6 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   public func refresh() {
-    hideActivityIndicatorOnNextLoad = true
     session.visit(controller, action: .replace)
   }
 
@@ -213,10 +210,6 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
 
   func showVisitableActivityIndicator() {
     guard !isRefreshing else { return }
-    guard !hideActivityIndicatorOnNextLoad else {
-      hideActivityIndicatorOnNextLoad = true
-      return
-    }
     onShowLoading?([:])
   }
 

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -57,6 +57,8 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   private var isRefreshing: Bool {
     controller.visitableView.isRefreshing
   }
+    
+  private var hideActivityIndicatorOnNextLoad = false
 
   // var isModal: Bool {
   //   return controller.reactViewController()?.isModal()
@@ -95,6 +97,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   public func refresh() {
+    hideActivityIndicatorOnNextLoad = true
     session.visit(controller, action: .replace)
   }
 
@@ -210,6 +213,10 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
 
   func showVisitableActivityIndicator() {
     guard !isRefreshing else { return }
+    guard !hideActivityIndicatorOnNextLoad else {
+      hideActivityIndicatorOnNextLoad = true
+      return
+    }
     onShowLoading?([:])
   }
 

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -31,6 +31,7 @@
   RCT_EXTERN_METHOD(injectJavaScript: (nonnull NSNumber) node
                     code: (nonnull NSString) code)
   RCT_EXTERN_METHOD(reload: (nonnull NSNumber) node)
+  RCT_EXTERN_METHOD(refresh: (nonnull NSNumber) node)
   RCT_EXTERN_METHOD(sendAlertResult: (nonnull NSNumber) node)
   RCT_EXTERN_METHOD(sendConfirmResult: (nonnull NSNumber) node
                     result: (nonnull NSString) code)

--- a/packages/turbo/ios/RNVisitableViewManager.swift
+++ b/packages/turbo/ios/RNVisitableViewManager.swift
@@ -34,6 +34,14 @@ class RNVisitableViewManager: RCTViewManager {
       component.reload()
     }
   }
+    
+  @objc
+  func refresh(_ node: NSNumber) {
+    DispatchQueue.main.async {
+      let component = self.bridge.uiManager.view(forReactTag: node) as! RNVisitableView
+      component.refresh()
+    }
+  }
 
   @objc
   func sendAlertResult(_ node: NSNumber) {

--- a/packages/turbo/src/RNSessionManager.ts
+++ b/packages/turbo/src/RNSessionManager.ts
@@ -1,9 +1,10 @@
 import { NativeModules } from 'react-native';
 
 interface RNSessionManager {
-  getRegisteredSessionHandles(): Promise<string[]>;
-  reloadSessionByName: (name: string) => Promise<void>;
-  clearSessionSnapshotCacheByName: (name: string) => Promise<void>;
+  getSessionHandles(): Promise<string[]>;
+  reloadSession: (name: string) => Promise<void>;
+  refreshSession: (name: string) => Promise<void>;
+  clearSessionSnapshotCache: (name: string) => Promise<void>;
 }
 
 const { RNSessionManager } = NativeModules as {
@@ -11,7 +12,8 @@ const { RNSessionManager } = NativeModules as {
 };
 
 export const {
-  getRegisteredSessionHandles,
-  reloadSessionByName,
-  clearSessionSnapshotCacheByName,
+  getSessionHandles,
+  reloadSession,
+  refreshSession,
+  clearSessionSnapshotCache,
 } = RNSessionManager;

--- a/packages/turbo/src/RNSessionManager.ts
+++ b/packages/turbo/src/RNSessionManager.ts
@@ -1,11 +1,17 @@
 import { NativeModules } from 'react-native';
 
 interface RNSessionManager {
-  clearSnapshotCacheForAllSessions(): void;
+  getRegisteredSessionHandles(): Promise<string[]>;
+  reloadSessionByName: (name: string) => Promise<void>;
+  clearSessionSnapshotCacheByName: (name: string) => Promise<void>;
 }
 
 const { RNSessionManager } = NativeModules as {
   RNSessionManager: RNSessionManager;
 };
 
-export const { clearSnapshotCacheForAllSessions } = RNSessionManager;
+export const {
+  getRegisteredSessionHandles,
+  reloadSessionByName,
+  clearSessionSnapshotCacheByName,
+} = RNSessionManager;

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -58,6 +58,7 @@ export interface Props {
 export interface RefObject {
   injectJavaScript: (callbackStringified: string) => void;
   reload: () => void;
+  refresh: () => void;
 }
 
 const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
@@ -120,6 +121,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
             callbackStringified
           ),
         reload: reloadVisitableView,
+        refresh: () => dispatchCommand(visitableViewRef, 'refresh'),
       }),
       [reloadVisitableView]
     );

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -79,6 +79,7 @@ export type StradaMessages = {
 export type DispatchCommandTypes =
   | 'injectJavaScript'
   | 'reload'
+  | 'refresh'
   | 'sendAlertResult'
   | 'sendConfirmResult';
 


### PR DESCRIPTION
## Summary

This PR:
1. Introduces `getSessionHandles()` method which returns sessionHandles which are available on the native side
2. Introduces `reloadSession(sessionHandle)` method which reloads WebView for given sessionHandle
3. Introduces `refreshSession(sessionHandle)` method which issues a replace visit for given sessionHandle
4. Refactors `clearSnapshotCacheForAllSessions()` to `clearSessionSnapshotCache(sessionHandle)`
5. Properly issues a replace visit in `didProposeVisit` function on iOS
6. Introduces `refresh` method on `VisitableView` component