### PR TITLE
Follow focused route while unpacking state

### DIFF
--- a/packages/navigation/src/utils/unpackState.ts
+++ b/packages/navigation/src/utils/unpackState.ts
@@ -3,7 +3,7 @@ import { getStateFromPath } from '@react-navigation/core';
 type ResultState = NonNullable<ReturnType<typeof getStateFromPath>>;
 
 export function unpackState(state: ResultState) {
-  const nestedState = state?.routes[0]?.state;
+  const nestedState = state?.routes[state.index ?? 0]?.state;
   if (nestedState) {
     return unpackState(nestedState);
   } else {


### PR DESCRIPTION
## Summary

This PR changes the behavior of a `unpackState` function - instead of unpacking the first route only we would like to respect the `state.index` value if present. 