### PR TITLE
Do not broadcast Strada message across all Strada components

### DIFF
--- a/packages/turbo/src/BridgeComponent.ts
+++ b/packages/turbo/src/BridgeComponent.ts
@@ -8,7 +8,10 @@ import type {
 
 const stradaMessageListener = (component: BridgeComponent) => (e: object) => {
   const message = e as StradaMessage;
-  if (message?.data?.metadata?.url !== component.url) {
+  if (
+    message?.component !== component.name ||
+    message?.data?.metadata?.url !== component.url
+  ) {
     return;
   }
   component.previousMessages[message.event] = message;


### PR DESCRIPTION
## Summary

This PR checks if name of the component is equal to the component name in Strada message. This way we make sure that the message is not broadcasted across all Strada components.