### PR TITLE
Compare significant params only

### DIFF
--- a/packages/navigation/src/hooks/useWebviewNavigate.ts
+++ b/packages/navigation/src/hooks/useWebviewNavigate.ts
@@ -17,7 +17,7 @@ import type {
   NavigatorScreenParams,
 } from '@react-navigation/core';
 import type { Action } from 'react-native-turbo';
-import { isDeepEqual } from '../utils/isEqual';
+import { isDeepEqual, type ComparableObject } from '../utils/isEqual';
 
 type ActionPayloadParams = {
   screen?: string;
@@ -93,6 +93,21 @@ function getAction(
   }
 }
 
+function areParamsSimilar(
+  existingParams: ComparableObject,
+  newParams: ComparableObject
+) {
+  const ignoredParams = {
+    path: undefined,
+    params: undefined,
+  };
+
+  const existingSignificantParams = { ...existingParams, ...ignoredParams };
+  const newSignificantParams = { ...newParams, ...ignoredParams };
+
+  return isDeepEqual(existingSignificantParams, newSignificantParams);
+}
+
 function getMinimalAction(
   action: NavigationAction,
   state: NavigationState
@@ -109,7 +124,7 @@ function getMinimalAction(
     payload?.name &&
     payload?.params?.screen &&
     currentState?.routes[currentState.index ?? -1]?.name === payload.name &&
-    isDeepEqual(
+    areParamsSimilar(
       currentState?.routes[currentState.index ?? -1]?.params,
       payload.params
     )

--- a/packages/navigation/src/utils/isEqual.ts
+++ b/packages/navigation/src/utils/isEqual.ts
@@ -1,4 +1,4 @@
-type ComparableObject = Readonly<
+export type ComparableObject = Readonly<
   | {
       [key: string]: any;
     }


### PR DESCRIPTION
## Summary

This PR adds a `areParamsSimilar` function to compare the params of 2 screens and see if they are to be considered “similar” enough to be removed. For this, we ignore path (which is always different, even if we should replace!) and params (which are also different).
