### PR TITLE
RNSession: do not set visitableView to nil when `visitableDidDisappear` is called

### DIFF
--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -61,12 +61,6 @@ class RNSession: NSObject {
   }()
   public lazy var webView: WKWebView = turboSession.webView
   
-  func visitableViewDidDisappear(view: RNVisitableView) {
-    if (view === visitableView) {
-      self.visitableView = nil
-    }
-  }
-  
   func visitableViewWillAppear(view: RNVisitableView) {
     self.visitableView = view
   }

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -193,7 +193,7 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
   }
 
   func visitableDidDisappear(visitable: Visitable) {
-    session.visitableViewDidDisappear(view: self)
+    // No-op
   }
 
   func visitableDidRender(visitable: Visitable) {


### PR DESCRIPTION
## Summary
This PR removes code responsible for setting `visitableView` property in `RNSession` when `visitableDidDisappear` is called - this had to be done because this method is called also when we switch sessionHandles - maintaining nil `visitableView` makes impossible to call `refreshSession` on a session which is backgrounded.