### PR TITLE
iOS: deinitialize controller when native component unmounts

### DIFF
--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -48,7 +48,8 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     return configuration
   }()
     
-  lazy var controller: RNVisitableViewController =  RNVisitableViewController(reactViewController: reactViewController(), delegate: self)
+  lazy var _controller: RNVisitableViewController? =  RNVisitableViewController(reactViewController: reactViewController(), delegate: self)
+  var controller: RNVisitableViewController { _controller! }
     
   private var isRefreshing: Bool {
     controller.visitableView.isRefreshing
@@ -65,6 +66,11 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     addSubview(controller.view)
   }
 
+  override func removeFromSuperview() {
+    super.removeFromSuperview()
+    _controller = nil
+  }
+    
   public func handleMessage(message: WKScriptMessage) {
     if let messageBody = message.body as? [AnyHashable : Any] {
       onMessage?(messageBody)


### PR DESCRIPTION
## Summary
This PR makes sure, that controller reference is removed when VisitableView native component is removed from superview. Before that we were maintaining controllers for every visited url. Right now it will only store as many controllers as registered sessions. 