### PR TITLE
Android: pass `RNSession` instance to `RNWebChromeClient`

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -26,7 +26,7 @@ class RNSession(
   private val applicationNameForUserAgent: String?,
 ) : SessionCallbackAdapter {
 
-  private var visitableView: SessionSubscriber? = null
+  var visitableView: SessionSubscriber? = null
 
   private val turboSession: TurboSession = run {
     val activity = reactContext.currentActivity as AppCompatActivity
@@ -37,7 +37,7 @@ class RNSession(
     webView.settings.setJavaScriptEnabled(true)
     webView.addJavascriptInterface(JavaScriptInterface(), "AndroidInterface")
     setUserAgentString(webView, applicationNameForUserAgent)
-    webView.webChromeClient = RNWebChromeClient(reactContext, visitableView)
+    webView.webChromeClient = RNWebChromeClient(reactContext, this@RNSession)
     session.isRunningInAndroidNavigation = false
     session
   }

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNWebChromeClient.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNWebChromeClient.kt
@@ -19,10 +19,11 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
 
 class RNWebChromeClient(
   private val reactContext: ReactApplicationContext,
-  private val visitableView: SessionSubscriber?
+  private val session: RNSession
 ) : ActivityEventListener, WebChromeClient() {
 
   private val fileChooserDelegate = RNFileChooserDelegate(reactContext)
+  private val visitableView: SessionSubscriber? get() = session.visitableView
 
   init {
     reactContext.addActivityEventListener(this)


### PR DESCRIPTION
## Summary
This PR fixes issues with opening the external browser and other actions which were handled by WebChromeClient. 