### PR TITLE
Call `onVisitProposal` with a delay

### DIFF
--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -144,7 +144,9 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
 
     const handleVisitProposal = useCallback(
       ({ nativeEvent }: NativeSyntheticEvent<VisitProposal>) => {
-        onVisitProposal(nativeEvent);
+        // Using requestAnimationFrame helps prevent a potential race condition
+        // that might occur between onFormSubmissionFinished and onVisitProposal.
+        requestAnimationFrame(() => onVisitProposal(nativeEvent));
       },
       [onVisitProposal]
     );

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -144,9 +144,9 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
 
     const handleVisitProposal = useCallback(
       ({ nativeEvent }: NativeSyntheticEvent<VisitProposal>) => {
-        // Using requestAnimationFrame helps prevent a potential race condition
-        // that might occur between onFormSubmissionFinished and onVisitProposal.
-        requestAnimationFrame(() => onVisitProposal(nativeEvent));
+        // Using setTimeout helps prevent a potential race condition
+        // that might occur between onFormSubmissionFinished and onVisitProposal
+        setTimeout(() => onVisitProposal(nativeEvent), 1);
       },
       [onVisitProposal]
     );


### PR DESCRIPTION
## Summary

In this PR, the `setTimeout` function wraps `onVisitProposal`. Sometimes `onVisitProposal` is invoked before `onFormSubmissionFinished`, and to prevent this behavior, we call `onVisitProposal` ### after a delay.

Using `setTimeout` instead of `requestAnimationFrame` provides a more generic solution. This is because `requestAnimationFrame` may behave differently on screens with higher refresh rates.