### PR TITLE
Android: do not detach WebView in RNSession

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -45,7 +45,6 @@ class RNSession(
   val currentVisit: TurboVisit? get() = turboSession.currentVisit
 
   internal fun registerVisitableView(newView: SessionSubscriber) {
-    visitableView?.detachWebView()
     visitableView = newView
   }
 


### PR DESCRIPTION
## Summary

This PR removes `detachWebView` call in `RNSession`. From now, `onDropViewInstance` in `RNVisitableViewManager` is  responsible for detaching WebView. This method properly calls `detachWebView` when needed (for example it's not called when changing bottom tabs).