### PR TITLE
Take snapshot when VisitableViewController is dismissed

### DIFF
--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -197,6 +197,11 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
   func visitableDidAppear(visitable: Visitable) {
     session.visitableViewDidAppear(view: self)
   }
+    
+  func visitableWillDisappear(visitable: Visitable) {
+    // snapshots are not always taken when VisitableViewController is dismissed
+    webView.evaluateJavaScript("Turbo.session.view.cacheSnapshot()")
+  }
 
   func visitableDidDisappear(visitable: Visitable) {
     // No-op

--- a/packages/turbo/ios/RNVisitableViewController.swift
+++ b/packages/turbo/ios/RNVisitableViewController.swift
@@ -15,6 +15,8 @@ public protocol RNVisitableViewControllerDelegate {
   func visitableDidAppear(visitable: Visitable)
   
   func visitableDidRender(visitable: Visitable)
+    
+  func visitableWillDisappear(visitable: Visitable)
   
   func visitableDidDisappear(visitable: Visitable)
   
@@ -59,6 +61,11 @@ class RNVisitableViewController: UIViewController, Visitable {
     
   override func viewDidDisappear(_ animated: Bool) {
     delegate?.visitableDidDisappear(visitable: self)
+  }
+    
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    delegate?.visitableWillDisappear(visitable: self)
   }
 
   // MARK: Visitable


### PR DESCRIPTION
## Summary
When navigating between view controllers not belonging to the same session, snapshots are not taken and potentially stale snapshots are being shown. This PR makes sure that snapshot is being taken when visitable will disappear.  