### PR TITLE
iOS: Make `controller` property optional in `RNVisitableView`

### DIFF
--- a/packages/turbo/ios/RNSessionSubscriber.swift
+++ b/packages/turbo/ios/RNSessionSubscriber.swift
@@ -10,7 +10,7 @@ import ReactNativeHotwiredTurboiOS
 protocol RNSessionSubscriber {
   
   var id: UUID { get set }
-  var controller: RNVisitableViewController { get }
+  var controller: RNVisitableViewController? { get }
   func handleMessage(message: WKScriptMessage)
   func didProposeVisit(proposal: VisitProposal)
   func didFailRequestForVisitable(visitable: Visitable, error: Error)

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -48,8 +48,13 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     return configuration
   }()
     
-  lazy var _controller: RNVisitableViewController? =  RNVisitableViewController(reactViewController: reactViewController(), delegate: self)
-  var controller: RNVisitableViewController { _controller! }
+  var _controller: RNVisitableViewController? = nil
+  var controller: RNVisitableViewController {
+    if (_controller == nil){
+      _controller = RNVisitableViewController(reactViewController: reactViewController(), delegate: self)
+    }
+    return _controller!
+  }
     
   private var isRefreshing: Bool {
     controller.visitableView.isRefreshing
@@ -119,6 +124,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   public func refresh() {
+    controller.visitableURL = URL(string: String(url))
     session.visit(controller, action: .replace)
   }
 

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -21,7 +21,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
   @objc var pullToRefreshEnabled: Bool = true {
     didSet {
-      controller.visitableView.allowsPullToRefresh = pullToRefreshEnabled
+      controller!.visitableView.allowsPullToRefresh = pullToRefreshEnabled
     }
   }
   @objc var onMessage: RCTDirectEventBlock?
@@ -48,16 +48,10 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     return configuration
   }()
     
-  var _controller: RNVisitableViewController? = nil
-  var controller: RNVisitableViewController {
-    if (_controller == nil){
-      _controller = RNVisitableViewController(reactViewController: reactViewController(), delegate: self)
-    }
-    return _controller!
-  }
+  lazy var controller: RNVisitableViewController? = RNVisitableViewController(reactViewController: reactViewController(), delegate: self)
     
   private var isRefreshing: Bool {
-    controller.visitableView.isRefreshing
+    controller!.visitableView.isRefreshing
   }
 
   // var isModal: Bool {
@@ -71,7 +65,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     // on its child view controllers. We need to manually begin the appearance transition
     // for the RNVisitableViewController when it's contained within a UIPageViewController.
     if (newWindow != nil && reactViewController()?.parent is UIPageViewController) {
-      controller.beginAppearanceTransition(true, animated: false)
+      controller!.beginAppearanceTransition(true, animated: false)
     }
   }
     
@@ -80,22 +74,22 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     guard window != nil else { return }
     
     let viewController = reactViewController()!
-    viewController.addChild(controller)
-    addSubview(controller.view)
-    controller.view.frame = bounds // Fixes incorrect size of the webview
-    controller.didMove(toParent: viewController)
+    viewController.addChild(controller!)
+    addSubview(controller!.view)
+    controller!.view.frame = bounds // Fixes incorrect size of the webview
+    controller!.didMove(toParent: viewController)
 
     // Sometimes UIPageViewController does not automatically call viewDidAppear
     // on its child view controllers. We need to manually end the appearance transition
     // for the RNVisitableViewController when it's contained within a UIPageViewController.
     if (viewController.parent is UIPageViewController) {
-      controller.endAppearanceTransition()
+      controller!.endAppearanceTransition()
     }
   }
 
   override func removeFromSuperview() {
     super.removeFromSuperview()
-    _controller = nil
+    controller = nil
   }
     
   public func handleMessage(message: WKScriptMessage) {
@@ -124,20 +118,20 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   public func refresh() {
-    controller.visitableURL = URL(string: String(url))
-    session.visit(controller, action: .replace)
+    guard controller != nil else { return }
+    session.visit(controller!, action: .replace)
   }
 
   private func visit() {
-    if (controller.visitableURL?.absoluteString == url as String) {
+    if (controller?.visitableURL?.absoluteString == url as String) {
       return
     }
     performVisit()
   }
 
   private func performVisit() {
-    controller.visitableURL = URL(string: String(url))
-    session.visit(controller)
+    controller!.visitableURL = URL(string: String(url))
+    session.visit(controller!)
   }
 
   public func didProposeVisit(proposal: VisitProposal){

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -71,7 +71,10 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     
   override func didMoveToWindow() {
     super.didMoveToWindow()
-    guard window != nil else { return }
+    
+    if (window == nil) {
+      return
+    }
     
     let viewController = reactViewController()!
     viewController.addChild(controller!)
@@ -118,7 +121,9 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   public func refresh() {
-    guard controller != nil else { return }
+    if (controller == nil) {
+      return
+    }
     session.visit(controller!, action: .replace)
   }
 
@@ -126,10 +131,6 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     if (controller?.visitableURL?.absoluteString == url as String) {
       return
     }
-    performVisit()
-  }
-
-  private func performVisit() {
     controller!.visitableURL = URL(string: String(url))
     session.visit(controller!)
   }
@@ -233,7 +234,9 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
   }
 
   func showVisitableActivityIndicator() {
-    guard !isRefreshing else { return }
+    if (isRefreshing) {
+      return
+    }
     onShowLoading?([:])
   }
 


### PR DESCRIPTION
## Summary

This PR makes the `controller` property optional in `RNVisitableView` on iOS. The reason for this change is to handle a case where we call `refreshSession` on a session that has no mounted native component. Currently, because we set controller property to `nil`, this results in an app crash.