### PR TITLE
Remove backgroundColor from default error and loading views

### DIFF
--- a/packages/turbo/src/hooks/useWebViewState.tsx
+++ b/packages/turbo/src/hooks/useWebViewState.tsx
@@ -100,7 +100,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     height: '100%',
     width: '100%',
-    backgroundColor: 'white',
     zIndex: 1,
   },
   title: {


### PR DESCRIPTION
I removed the `backgroundColor` from the error and loading view wrappers. This causes the views to be transparent and therefore it won't show a white loading screen when the color scheme is dark or otherwise incompatible with the color scheme of the app.