### PR TITLE
RNVisitableView: check for `reactTag` existence

### DIFF
--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -79,11 +79,13 @@ export function dispatchCommand(
     return;
   }
 
-  UIManager.dispatchViewManagerCommand(
-    findNodeHandle(ref.current),
-    transformedCommand,
-    args
-  );
+  const reactTag = findNodeHandle(ref.current);
+
+  if (!reactTag) {
+    return;
+  }
+
+  UIManager.dispatchViewManagerCommand(reactTag, transformedCommand, args);
 }
 
 export async function openExternalURL({


### PR DESCRIPTION
## Summary

This PR checks if reactTag has a value different than `null` -> this way we avoid potential crash. 