### PR TITLE
Avoid calling the native method before the native `sessionHandle` prop is set up

### DIFF
--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -20,6 +20,7 @@ import type {
   FormSubmissionEvent,
   ContentProcessDidTerminateEvent,
 } from './types';
+import { nextEventLoopTick } from './utils/nextEventLoopTick';
 
 // interface should match RNVisitableView exported properties in native code
 export interface RNVisitableViewProps {
@@ -80,10 +81,14 @@ export function dispatchCommand(
     return;
   }
 
-  UIManager.dispatchViewManagerCommand(
-    findNodeHandle(ref.current),
-    transformedCommand,
-    args
+  // Using nextEventLoopTick helps prevent a potential race condition.
+  // It avoids calling the native method before the native sessionHandle prop is set up.
+  nextEventLoopTick(() =>
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(ref.current),
+      transformedCommand,
+      args
+    )
   );
 }
 

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -83,13 +83,13 @@ export function dispatchCommand(
 
   // Using nextEventLoopTick helps prevent a potential race condition.
   // It avoids calling the native method before the native sessionHandle prop is set up.
-  nextEventLoopTick(() =>
-    UIManager.dispatchViewManagerCommand(
-      findNodeHandle(ref.current),
-      transformedCommand,
-      args
-    )
-  );
+  nextEventLoopTick(() => {
+    const reactTag = findNodeHandle(ref.current);
+
+    if (reactTag) {
+      UIManager.dispatchViewManagerCommand(reactTag, transformedCommand, args);
+    }
+  });
 }
 
 export async function openExternalURL({

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -35,6 +35,7 @@ import type {
   FormSubmissionEvent,
   ContentProcessDidTerminateEvent,
 } from './types';
+import { nextEventLoopTick } from './utils/nextEventLoopTick';
 
 export interface Props {
   url: string;
@@ -145,9 +146,9 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
 
     const handleVisitProposal = useCallback(
       ({ nativeEvent }: NativeSyntheticEvent<VisitProposal>) => {
-        // Using setTimeout helps prevent a potential race condition
+        // Using nextEventLoopTick helps prevent a potential race condition
         // that might occur between onFormSubmissionFinished and onVisitProposal
-        setTimeout(() => onVisitProposal(nativeEvent), 1);
+        nextEventLoopTick(() => onVisitProposal(nativeEvent));
       },
       [onVisitProposal]
     );

--- a/packages/turbo/src/utils/nextEventLoopTick.ts
+++ b/packages/turbo/src/utils/nextEventLoopTick.ts
@@ -1,0 +1,3 @@
+export function nextEventLoopTick(callback: () => void) {
+  setTimeout(callback, 1);
+}


### PR DESCRIPTION
## Summary

This PR 
1. Wraps `dispatchViewManagerCommand` function with `setTimeout`. This way we avoid calling the native method before the native `sessionHandle` prop is set up. 
2. Introduces `nextEventLoopTick` function whose purpose is to map the behavior of [process.nextTick](https://nodejs.org/docs/latest/api/process.html#processnexttickcallback-args) function. 

