### PR TITLE
Releases: get package name from `npm` object

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -13,7 +13,7 @@ module.exports = {
     requireCommitsFail: false,
     requireUpstream: false,
     commitMessage: 'Release ${name}@${version}',
-    tagName: '${name}@${version}',
+    tagName: '${npm.name}@${version}',
     pushArgs: ['--follow-tags', '--force'],
   },
   github: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

As described [here](https://github.com/release-it/release-it/issues/933), we need to obtain package name from `npm` object.

## Test plan

`yarn release`