### PR TITLE
Fix issue with routes in `getStateForPath`

### DIFF
--- a/packages/navigation/src/buildWebScreen.tsx
+++ b/packages/navigation/src/buildWebScreen.tsx
@@ -1,28 +1,28 @@
 import {
-  PartialRoute,
-  Route,
   getStateFromPath,
+  PartialState,
 } from '@react-navigation/native';
+import type { NavigationState } from '@react-navigation/core';
 
 import { LinkingConfig } from './hooks/useCurrentUrl';
 import { unpackState } from './utils/unpackState';
 
 type Options = Parameters<typeof getStateFromPath>[1];
 type LinkedParams = { baseURL?: string; fullPath?: string };
-type PartialRoutes = readonly PartialRoute<Route<string, object | undefined>>[];
 
 function getParams(
-  routes: PartialRoutes | undefined
+  state: NavigationState | PartialState<NavigationState>
 ): LinkedParams | undefined {
-  const firstRoute = routes?.[0];
-  if (firstRoute) {
-    if (firstRoute.params) {
-      return firstRoute.params;
+  const activeRoute = state.routes?.[state.index ?? 0];
+
+  if (activeRoute) {
+    if (activeRoute.params) {
+      return activeRoute.params;
     } else {
       // route is readonly object (in types). But we need to hack it be non-empty
       // @ts-expect-error
-      firstRoute.params = {};
-      return firstRoute.params;
+      activeRoute.params = {};
+      return activeRoute.params;
     }
   }
   return undefined;
@@ -35,7 +35,7 @@ export function getLinkingObject(baseURL: string, linking: LinkingConfig) {
     getStateFromPath(path: string, options?: Options) {
       const state = getStateFromPath(path, options);
       if (state) {
-        const params = getParams(unpackState(state)?.routes);
+        const params = getParams(unpackState(state));
         if (params) {
           params.baseURL = baseURL;
           params.fullPath = path;

--- a/packages/navigation/src/buildWebScreen.tsx
+++ b/packages/navigation/src/buildWebScreen.tsx
@@ -1,8 +1,5 @@
-import {
-  getStateFromPath,
-  PartialState,
-} from '@react-navigation/native';
 import type { NavigationState } from '@react-navigation/core';
+import { getStateFromPath, PartialState } from '@react-navigation/native';
 
 import { LinkingConfig } from './hooks/useCurrentUrl';
 import { unpackState } from './utils/unpackState';


### PR DESCRIPTION
This PR fixes a bug where the `fullPath` param was always set on the first route in the unpacked state. The first route might not always be the active one, so this PR changes it to use the states `index` to determine the active route in the `routes`.