### PR TITLE
Android: override default value of empty `<title>` tag

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -260,6 +260,19 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     reactContext.getJSModule(RCTEventEmitter::class.java).receiveEvent(id, event.name, params)
   }
 
+  private fun getWebViewTitle(): String {
+    // When the <title> tag is empty, the WebView's title is set to the URL.
+    // In this case, we want to return the empty string instead of the URL.
+    var title = webView.title ?: return ""
+    val url = webView.url ?: return title
+    val urlWithoutProtocol = url.replaceFirst("https?://".toRegex(), "")
+    
+    // In case of an empty <title> on the root path, it results in the same string as the host.
+    title += "/"
+    
+    return if (title.startsWith(urlWithoutProtocol)) "" else title
+  }
+
   // region SessionSubscriber
 
   override fun injectJavaScript(script: String) {
@@ -313,7 +326,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
   override fun visitRendered() {
     sendEvent(RNVisitableViewEvent.LOAD, Arguments.createMap().apply {
-      putString("title", webView.title)
+      putString("title", getWebViewTitle())
       putString("url", webView.url)
     })
     removeTransitionalViews()
@@ -321,7 +334,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
   override fun visitCompleted(completedOffline: Boolean) {
     sendEvent(RNVisitableViewEvent.LOAD, Arguments.createMap().apply {
-      putString("title", webView.title)
+      putString("title", getWebViewTitle())
       putString("url", webView.url)
     })
     CookieManager

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -260,19 +260,6 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     reactContext.getJSModule(RCTEventEmitter::class.java).receiveEvent(id, event.name, params)
   }
 
-  private fun getWebViewTitle(): String {
-    // When the <title> tag is empty, the WebView's title is set to the URL.
-    // In this case, we want to return the empty string instead of the URL.
-    var title = webView.title ?: return ""
-    val url = webView.url ?: return title
-    val urlWithoutProtocol = url.replaceFirst("https?://".toRegex(), "")
-    
-    // In case of an empty <title> on the root path, it results in the same string as the host.
-    title += "/"
-    
-    return if (title.startsWith(urlWithoutProtocol)) "" else title
-  }
-
   // region SessionSubscriber
 
   override fun injectJavaScript(script: String) {
@@ -326,7 +313,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
   override fun visitRendered() {
     sendEvent(RNVisitableViewEvent.LOAD, Arguments.createMap().apply {
-      putString("title", getWebViewTitle())
+      putString("title", webView.title)
       putString("url", webView.url)
     })
     removeTransitionalViews()
@@ -334,7 +321,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
 
   override fun visitCompleted(completedOffline: Boolean) {
     sendEvent(RNVisitableViewEvent.LOAD, Arguments.createMap().apply {
-      putString("title", getWebViewTitle())
+      putString("title", webView.title)
       putString("url", webView.url)
     })
     CookieManager

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -138,9 +138,19 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
     );
 
     const handleOnLoad = useCallback(
-      ({ nativeEvent }: NativeSyntheticEvent<LoadEvent>) => {
+      ({ nativeEvent: { url, title } }: NativeSyntheticEvent<LoadEvent>) => {
         initializeStradaBridge();
-        onLoad?.(nativeEvent);
+
+        // On Android, if the <title> tag is empty, the WebView's title defaults to the URL.
+        // We want to return an empty string in this case, not the URL.
+        const parsedUrl = new URL(url);
+        const path = parsedUrl.pathname === '/' ? '' : parsedUrl.pathname;
+
+        if (title.startsWith(`${parsedUrl.host}${path}`)) {
+          title = '';
+        }
+
+        onLoad?.({ url, title });
       },
       [initializeStradaBridge, onLoad]
     );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

When `<title>` tag is empty, native WebView on Android sets the title to `host + path`. That's a different behavior from `WKWebView` on iOS. This PR makes sure that we get the same title result.

Note: if someone sets the title to the host (e.g., swmansion.com), it will be set to an empty string. In this case, to use a `host + path` combination as a title, it should be set in the `options` parameter in `react-navigation`.

## Test plan

Set the title tag to empty string and check if value is correct.
