### PR TITLE
iOS: make sure that `WKWebView` has correct size

### DIFF
--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -48,6 +48,7 @@ class RNSession: NSObject {
     let session = Session(webViewConfiguration: webViewConfiguration)
     session.delegate = self
     session.webView.allowsLinkPreview = false
+    session.webView.scrollView.contentInsetAdjustmentBehavior = .never
     session.webView.uiDelegate = self.wkUiDelegate
 
     #if DEBUG


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

`WKWebView` by default calculates the safe area for displaying the page content. This sometimes results in the content being cropped. Setting `contentInsetAdjustmentBehavior` to `.never` will override this default behavior.

## Test plan

Made sure that everything is displayed correctly.