### PR TITLE
iOS: fix compilation warnings

### DIFF
--- a/packages/turbo/ios/RNSessionManager.m
+++ b/packages/turbo/ios/RNSessionManager.m
@@ -5,6 +5,8 @@
 //  Created by Patryk Klatka on 05/01/2024.
 //
 
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
+
 #import <React/RCTBridgeModule.h>
 
 @interface RCT_EXTERN_MODULE(RNSessionManager, NSObject)

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -165,7 +165,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   public func didFailRequestForVisitable(visitable: Visitable, error: Error){
-    var event: [AnyHashable: Any] = [
+    let event: [AnyHashable: Any] = [
       "url": visitable.visitableURL.absoluteString,
       "description": error.localizedDescription,
       "statusCode": getStatusCodeFromError(error: error as? TurboError)

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -5,6 +5,8 @@
 //  Created by Bartłomiej Fryz on 22/06/2022.
 //
 
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
+
 #import <React/RCTViewManager.h>
 #import <React/RCTEventEmitter.h>
 #import <React/RCTBridgeModule.h>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR fixes warnings which occur during compilation.

## Test plan

`yarn clean && yarn && cd examples/turbo-native-expo-example && yarn ios`