### PR TITLE
Change logic of `refresh` method

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -24,8 +24,8 @@ import dev.hotwire.turbo.errors.WebSslError
 import dev.hotwire.turbo.visit.TurboVisitAction
 
 const val REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function'" +
-        "? Turbo.session.refresh(document.baseURI)" +
-        ": Turbo.visit(document.baseURI, { action: 'replace', shouldCacheSnapshot: 'false' })"
+        "? Turbo.session.refresh(document.baseURI)" + // Turbo 8+
+        ": Turbo.visit(document.baseURI, { action: 'replace', shouldCacheSnapshot: 'false' })" // Older Turbo versions 
 
 class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscriber {
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -23,9 +23,9 @@ import dev.hotwire.turbo.errors.WebError
 import dev.hotwire.turbo.errors.WebSslError
 import dev.hotwire.turbo.visit.TurboVisitAction
 
-const val REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function' " +
+const val REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function'" +
         "? Turbo.session.refresh(document.baseURI)" +
-        ": Turbo.visit(document.baseURI, {action: 'replace', shouldCacheSnapshot: 'false'})"
+        ": Turbo.visit(document.baseURI, { action: 'replace', shouldCacheSnapshot: 'false' })"
 
 class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscriber {
 

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -23,6 +23,10 @@ import dev.hotwire.turbo.errors.WebError
 import dev.hotwire.turbo.errors.WebSslError
 import dev.hotwire.turbo.visit.TurboVisitAction
 
+const val REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function' " +
+        "? Turbo.session.refresh(document.baseURI)" +
+        ": Turbo.visit(document.baseURI, {action: 'replace', shouldCacheSnapshot: 'false'})"
+
 class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscriber {
 
   private val reactContext = context as ReactApplicationContext
@@ -117,13 +121,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun refresh() {
-    session.visit(
-      url = url,
-      restoreWithCachedSnapshot = false,
-      reload = false,
-      viewTreeLifecycleOwner = viewTreeLifecycleOwner,
-      visitOptions = TurboVisitOptions(action = TurboVisitAction.REPLACE)
-    )
+    webView.evaluateJavascript(REFRESH_SCRIPT, null)
   }
 
   override fun reload(displayProgress: Boolean) {

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -8,8 +8,8 @@
 import UIKit
 
 let REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function'" +
-            "? Turbo.session.refresh(document.baseURI)" +
-            ": Turbo.visit(document.baseURI, { action: 'replace', shouldCacheSnapshot: 'false' })"
+            "? Turbo.session.refresh(document.baseURI)" + // Turbo 8+
+            ": Turbo.visit(document.baseURI, { action: 'replace', shouldCacheSnapshot: 'false' })" // Older Turbo versions
 
 class RNVisitableView: UIView, RNSessionSubscriber {
   var id: UUID = UUID()

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -7,7 +7,9 @@
 
 import UIKit
 
-let REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function' ? Turbo.session.refresh(document.baseURI) : Turbo.visit(document.baseURI, {action: 'replace', shouldCacheSnapshot: 'false'})"
+let REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function'" +
+            "? Turbo.session.refresh(document.baseURI)" +
+            ": Turbo.visit(document.baseURI, { action: 'replace', shouldCacheSnapshot: 'false' })"
 
 class RNVisitableView: UIView, RNSessionSubscriber {
   var id: UUID = UUID()

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+let REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function' ? Turbo.session.refresh(document.baseURI) : Turbo.visit(document.baseURI, {action: 'replace', shouldCacheSnapshot: 'false'})"
+
 class RNVisitableView: UIView, RNSessionSubscriber {
   var id: UUID = UUID()
   @objc var sessionHandle: NSString? = nil
@@ -120,10 +122,7 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   public func refresh() {
-    if (controller == nil) {
-      return
-    }
-    session.visit(controller!, action: .replace)
+      webView.evaluateJavaScript(REFRESH_SCRIPT)
   }
 
   private func visit() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR changes the logic of `refresh` method - we no longer dispatch `replace` visit, instead, the JS script is injected which calls `refresh()` method on `Turbo.session` object. 

## Test plan

Added a `setTimeout` in `WebView.tsx` and checked if website is refreshed properly.