### PR TITLE
Ensure that `webViewRef` is initialized in `initializeWebView` function

### DIFF
--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -62,9 +62,16 @@ function transformCommandToAcceptableType(command: number): number | string {
 }
 
 const initializeWebView = async (webViewRef: React.RefObject<any>) => {
-  webViewRef.current.initializationPromise ||= new Promise<void>((resolve) =>
+  const initializationPromise = new Promise<void>((resolve) =>
     setTimeout(resolve, 1)
   );
+
+  if (!webViewRef?.current) {
+    return initializationPromise;
+  }
+
+  webViewRef.current.initializationPromise ||= initializationPromise;
+
   return webViewRef.current.initializationPromise;
 };
 
@@ -93,9 +100,11 @@ export async function dispatchCommand(
 
   const reactTag = findNodeHandle(ref.current);
 
-  if (reactTag) {
-    UIManager.dispatchViewManagerCommand(reactTag, transformedCommand, args);
+  if (!reactTag) {
+    return;
   }
+
+  UIManager.dispatchViewManagerCommand(reactTag, transformedCommand, args);
 }
 
 export async function openExternalURL({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR refactors the `initializeWebView` function to ensure that `webViewRef` is properly initialized and changes the `dispatchCommand` function body to always use early returns. This addresses some edge cases where `webViewRef` could potentially be uninitialized.

## Test plan

`yarn && yarn dev:ios`