### PR TITLE
Android: ensure that `WebView` is detached when application context is available

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -98,6 +98,15 @@ class RNVisitableViewManager(
 
   override fun onDropViewInstance(view: RNVisitableView) {
     super.onDropViewInstance(view)
+    
+    // If the applicationContext is null, it can indicate that the application
+    // has not been fully created yet or the application process is being terminated.
+    // In such cases, we stop the execution of the method. The similar check is done 
+    // in the `onDropViewInstance` method of the `ViewManager`.
+    if (callerContext.applicationContext == null) {
+      return
+    }
+
     view.detachWebView()
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR adds a check in `onDropViewInstance` which ensures that `detachWebView` is called when the app context is available. A similar check is done in `ViewManager.onDropViewInstance` when recycling the view.
