### PR TITLE
iOS: ensure that all completion handlers have been called

### DIFF
--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -222,8 +222,8 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
   }
     
   func visitableWillDisappear(visitable: Visitable) {
-    // Make sure that all completion handlers have been called.
-    // Otherwise we might end up with a NSInternalInconsistencyException.
+    // Ensure that all completion handlers have been called.
+    // Otherwise, an NSInternalInconsistencyException might occur.
     sendAlertResult()
     sendConfirmResult(result: "")
   }

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -220,6 +220,13 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
   func visitableDidAppear(visitable: Visitable) {
     session.visitableViewDidAppear(view: self)
   }
+    
+  func visitableWillDisappear(visitable: Visitable) {
+    // Make sure that all completion handlers have been called.
+    // Otherwise we might end up with a NSInternalInconsistencyException.
+    sendAlertResult()
+    sendConfirmResult(result: "")
+  }
 
   func visitableDidDisappear(visitable: Visitable) {
     // No-op

--- a/packages/turbo/ios/RNVisitableViewController.swift
+++ b/packages/turbo/ios/RNVisitableViewController.swift
@@ -14,6 +14,8 @@ public protocol RNVisitableViewControllerDelegate {
   func visitableDidAppear(visitable: Visitable)
   
   func visitableDidRender(visitable: Visitable)
+    
+  func visitableWillDisappear(visitable: Visitable)
   
   func visitableDidDisappear(visitable: Visitable)
   
@@ -54,6 +56,11 @@ class RNVisitableViewController: UIViewController, Visitable {
     super.viewDidAppear(animated)
     visitableDelegate?.visitableViewDidAppear(self)
     delegate?.visitableDidAppear(visitable: self)
+  }
+    
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    delegate?.visitableWillDisappear(visitable: self)
   }
     
   override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR makes sure that all completion handlers have been called before webView navigates to other url. There is a possibility that `sendAlertResult` or `sendConfirmResult` are going to be called too late which can result in `NSInternalInconsistencyException`.
