### PR TITLE
VisitableView: introduce `webViewDebuggingEnabled` property

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNSession.kt
@@ -2,13 +2,11 @@ package com.reactnativeturbowebview
 
 import android.webkit.JavascriptInterface
 import android.webkit.WebSettings
-import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.whenStateAtLeast
-import com.facebook.react.BuildConfig
 import com.facebook.react.bridge.ReactApplicationContext
 import dev.hotwire.turbo.errors.TurboVisitError
 import dev.hotwire.turbo.session.TurboSession
@@ -34,7 +32,6 @@ class RNSession(
     val webView = TurboWebView(activity, null)
     val session = TurboSession(sessionHandle, activity, webView)
 
-    WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG)
     webView.settings.setJavaScriptEnabled(true)
     webView.addJavascriptInterface(JavaScriptInterface(), "AndroidInterface")
     setUserAgentString(webView, applicationNameForUserAgent)

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableView.kt
@@ -5,7 +5,7 @@ import android.graphics.Bitmap
 import android.view.MotionEvent
 import android.view.ViewGroup
 import android.webkit.CookieManager
-import android.webkit.WebSettings
+import android.webkit.WebView
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.view.isVisible
@@ -64,6 +64,11 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
           it.getInt("end")
         )
       }
+    }
+  var webViewDebuggingEnabled: Boolean = false
+    set(value) {
+      field = value
+      WebView.setWebContentsDebuggingEnabled(value)
     }
 
   // Session

--- a/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativeturbowebview/RNVisitableViewManager.kt
@@ -68,6 +68,11 @@ class RNVisitableViewManager(
     view.progressViewOffset = progressViewOffset
   }
 
+  @ReactProp(name = "webViewDebuggingEnabled")
+  fun setWebViewDebuggingEnabled(view: RNVisitableView, webViewDebuggingEnabled: Boolean) {
+    view.webViewDebuggingEnabled = webViewDebuggingEnabled
+  }
+
   override fun getCommandsMap(): MutableMap<String, Int> = RNVisitableViewCommand.values()
     .associate {
       it.jsCallbackName to it.ordinal

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -50,12 +50,6 @@ class RNSession: NSObject {
     session.webView.allowsLinkPreview = false
     session.webView.scrollView.contentInsetAdjustmentBehavior = .never
     session.webView.uiDelegate = self.wkUiDelegate
-
-    #if DEBUG
-    if #available(iOS 16.4, *) {
-      session.webView.isInspectable = true
-    }
-    #endif
     
     return session
   }()

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -169,11 +169,11 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   private func visit() {
-    if (controller?.visitableURL?.absoluteString == url as String || session == nil) {
+    if (controller?.visitableURL?.absoluteString == url as String) {
       return
     }
     controller!.visitableURL = URL(string: String(url))
-    session!.visit(controller!)
+    session?.visit(controller!)
   }
 
   public func didProposeVisit(proposal: VisitProposal){

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -14,13 +14,7 @@ let REFRESH_SCRIPT = "typeof Turbo.session.refresh === 'function'" +
 class RNVisitableView: UIView, RNSessionSubscriber {
   var id: UUID = UUID()
   @objc var sessionHandle: NSString? = nil
-  @objc var url: NSString = "" {
-    didSet {
-      if(url != oldValue) {
-        visit()
-      }
-    }
-  }
+  @objc var url: NSString = ""
   @objc var applicationNameForUserAgent: NSString? = nil {
     didSet {
       webViewConfiguration.applicationNameForUserAgent = applicationNameForUserAgent as? String
@@ -37,6 +31,11 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     }
   }
   @objc var contentInset: [String: CGFloat] = [:] {
+    didSet {
+      configureWebView()
+    }
+  }
+  @objc var webViewDebuggingEnabled: Bool = false {
     didSet {
       configureWebView()
     }
@@ -83,7 +82,11 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     if (webView == nil) {
       return
     }
-    
+      
+    if #available(iOS 16.4, *) {
+      webView!.isInspectable = webViewDebuggingEnabled
+    }
+
     webView!.scrollView.isScrollEnabled = scrollEnabled
     webView!.scrollView.contentInset = UIEdgeInsets(top: contentInset["top"] ?? 0,
                                                     left: contentInset["left"] ?? 0,
@@ -122,6 +125,13 @@ class RNVisitableView: UIView, RNSessionSubscriber {
       controller!.endAppearanceTransition()
     }
   }
+    
+  override func didSetProps(_ changedProps: [String]!) {
+    super.didSetProps(changedProps)
+
+    // When all properties of RNVisitableView are initialized, the visit function can be safely called.
+    visit()
+  }
 
   override func removeFromSuperview() {
     super.removeFromSuperview()
@@ -159,11 +169,11 @@ class RNVisitableView: UIView, RNSessionSubscriber {
   }
 
   private func visit() {
-    if (controller?.visitableURL?.absoluteString == url as String) {
+    if (controller?.visitableURL?.absoluteString == url as String || session == nil) {
       return
     }
     controller!.visitableURL = URL(string: String(url))
-    session?.visit(controller!)
+    session!.visit(controller!)
   }
 
   public func didProposeVisit(proposal: VisitProposal){

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -19,6 +19,7 @@
   RCT_EXPORT_VIEW_PROPERTY(pullToRefreshEnabled, BOOL)
   RCT_EXPORT_VIEW_PROPERTY(scrollEnabled, BOOL)
   RCT_EXPORT_VIEW_PROPERTY(contentInset, NSDictionary)
+  RCT_EXPORT_VIEW_PROPERTY(webViewDebuggingEnabled, BOOL)
   RCT_EXPORT_VIEW_PROPERTY(onVisitProposal, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onOpenExternalUrl, RCTDirectEventBlock)
   RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -32,6 +32,7 @@ export interface RNVisitableViewProps {
   scrollEnabled: boolean;
   contentInset: ContentInsetObject;
   progressViewOffset?: ProgressViewOffsetObject;
+  webViewDebuggingEnabled: boolean;
   onLoad?: (e: NativeSyntheticEvent<LoadEvent>) => void;
   onMessage?: (e: NativeSyntheticEvent<MessageEvent>) => void;
   onError?: (e: NativeSyntheticEvent<ErrorEvent>) => void;

--- a/packages/turbo/src/VisitableView.tsx
+++ b/packages/turbo/src/VisitableView.tsx
@@ -54,6 +54,7 @@ export interface Props {
   scrollEnabled?: boolean;
   contentInset?: ContentInsetObject;
   progressViewOffset?: ProgressViewOffsetObject;
+  webViewDebuggingEnabled?: boolean;
   renderLoading?: RenderLoading;
   renderError?: RenderError;
   onVisitProposal: (proposal: VisitProposal) => void;
@@ -86,6 +87,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
       scrollEnabled = true,
       contentInset = { top: 0, left: 0, right: 0, bottom: 0 },
       progressViewOffset,
+      webViewDebuggingEnabled = false,
       renderLoading,
       renderError,
       onLoad,
@@ -225,6 +227,7 @@ const VisitableView = React.forwardRef<RefObject, React.PropsWithRef<Props>>(
           scrollEnabled={scrollEnabled}
           contentInset={contentInset}
           progressViewOffset={progressViewOffset}
+          webViewDebuggingEnabled={webViewDebuggingEnabled}
           onError={onErrorCombinedHandlers}
           onVisitProposal={handleVisitProposal}
           onMessage={handleOnMessage}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR: 
1. Introduces `webViewDebuggingEnabled` property on `VisitableView` to enable the remote debugging using Safari / Chrome. Now remote debugging is disabled by default, but can be enabled by setting the property to `true`. 
2. Changes the place of calling the `visit()` function in `RNVisitableView.swift`. Now the `visit()` function is called in `didSetProps` to make sure that all props are being initialized. Without that change, somehow url `didSet` is called before `sessionHandle` which causes the WKWebView not to mount.

## Test plan

Tested on iOS and Android using the example app.