### PR TITLE
Strada: change the way of passing the message object to `window.webBridge` 

### DIFF
--- a/packages/turbo/src/hooks/useStradaBridge.ts
+++ b/packages/turbo/src/hooks/useStradaBridge.ts
@@ -38,7 +38,7 @@ export const useStradaBridge = (
       dispatchCommand(
         visitableViewRef,
         'injectJavaScript',
-        `window.nativeBridge.replyWith('${JSON.stringify(message)}')`
+        `window.nativeBridge.replyWith(${JSON.stringify(message)})`
       ),
     [dispatchCommand, visitableViewRef]
   );

--- a/packages/turbo/src/utils/stradaBridgeScript.ts
+++ b/packages/turbo/src/utils/stradaBridgeScript.ts
@@ -63,7 +63,7 @@ export const stradaBridgeScript = `
     // Reply to web with message
     replyWith(message) {
       if (this.isStradaAvailable) {
-        this.webBridge.receive(JSON.parse(message));
+        this.webBridge.receive(message);
       }
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect. -->

## Summary

This PR changes the way of passing the message object to `window.webBridge` in `sendToBridge` function - previous approach was causing a crash when someone passed a string with  unescaped `'` character - now the object is passed without wrapping it with a string.
