### PR TITLE
Fix BridgeComponents after Turbo Frame navigations or redirects

### DIFF
--- a/packages/turbo/src/BridgeComponent.ts
+++ b/packages/turbo/src/BridgeComponent.ts
@@ -5,14 +5,12 @@ import type {
   StradaMessage,
   StradaMessages,
   StradaComponentProps,
+  SessionMessageCallback,
 } from './types';
 
 const stradaMessageListener = (component: BridgeComponent) => (e: object) => {
   const message = e as StradaMessage;
-  if (
-    message?.component !== component.name ||
-    message?.data?.metadata?.url !== component.url
-  ) {
+  if (message?.component !== component.name) {
     return;
   }
   component.previousMessages[message.event] = message;
@@ -25,7 +23,9 @@ class BridgeComponent extends Component<StradaComponentProps> {
   sessionHandle: string;
   messageEventListenerSubscription?: EmitterSubscription;
   previousMessages: StradaMessages = {};
-  registerMessageListener: (listener: (e: object) => void) => void;
+  registerMessageListener: (
+    listener: SessionMessageCallback
+  ) => EmitterSubscription;
   sendToBridge: (message: StradaMessage) => void;
 
   constructor(props: StradaComponentProps) {
@@ -42,7 +42,9 @@ class BridgeComponent extends Component<StradaComponentProps> {
   }
 
   componentDidMount() {
-    this.registerMessageListener(stradaMessageListener(this));
+    this.messageEventListenerSubscription = this.registerMessageListener(
+      stradaMessageListener(this)
+    );
   }
 
   componentWillUnmount() {

--- a/packages/turbo/src/BridgeComponent.ts
+++ b/packages/turbo/src/BridgeComponent.ts
@@ -1,11 +1,11 @@
 import { Component } from 'react';
-import type { EmitterSubscription } from 'react-native';
 
 import type {
   StradaMessage,
   StradaMessages,
   StradaComponentProps,
   SessionMessageCallback,
+  EventSubscription,
 } from './types';
 
 const stradaMessageListener = (component: BridgeComponent) => (e: object) => {
@@ -21,11 +21,11 @@ class BridgeComponent extends Component<StradaComponentProps> {
   name: string;
   url: string;
   sessionHandle: string;
-  messageEventListenerSubscription?: EmitterSubscription;
+  messageEventListenerSubscription?: EventSubscription;
   previousMessages: StradaMessages = {};
   registerMessageListener: (
     listener: SessionMessageCallback
-  ) => EmitterSubscription;
+  ) => EventSubscription;
   sendToBridge: (message: StradaMessage) => void;
 
   constructor(props: StradaComponentProps) {

--- a/packages/turbo/src/hooks/useMessageQueue.ts
+++ b/packages/turbo/src/hooks/useMessageQueue.ts
@@ -15,6 +15,14 @@ export function useMessageQueue(
   const registerMessageListener = useCallback(
     (listener: SessionMessageCallback) => {
       onMessageCallbacks.current.push(listener);
+
+      return {
+        remove: () => {
+          onMessageCallbacks.current = onMessageCallbacks.current.filter(
+            (callback) => callback !== listener
+          );
+        },
+      };
     },
     []
   );

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -1,3 +1,5 @@
+import { EmitterSubscription } from "react-native";
+
 export type Action = 'advance' | 'replace' | 'restore';
 
 export interface VisitProposal {
@@ -76,7 +78,7 @@ export type StradaComponentProps = {
   sessionHandle: string;
   url: string;
   name: string;
-  registerMessageListener: (listener: SessionMessageCallback) => void;
+  registerMessageListener: (listener: SessionMessageCallback) => EmitterSubscription;
   sendToBridge: (message: StradaMessage) => void;
 };
 

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -1,5 +1,3 @@
-import { EmitterSubscription } from "react-native";
-
 export type Action = 'advance' | 'replace' | 'restore';
 
 export interface VisitProposal {
@@ -74,11 +72,17 @@ export type SessionMessageCallback = (message: object) => void;
 
 export type OnErrorCallback = (error: ErrorEvent) => void;
 
+export type EventSubscription = {
+  remove: () => void;
+};
+
 export type StradaComponentProps = {
   sessionHandle: string;
   url: string;
   name: string;
-  registerMessageListener: (listener: SessionMessageCallback) => EmitterSubscription;
+  registerMessageListener: (
+    listener: SessionMessageCallback
+  ) => EventSubscription;
   sendToBridge: (message: StradaMessage) => void;
 };
 


### PR DESCRIPTION
## Summary

This PR is an alternative to #227 that fixes issues with Strada Bridge Components as URLs change. It also fixes a bug in the existing code, where message listeners were not removed as bridge components were unmounted. The PR here is universal and works for both Android and iOS.

Strada Bridge Components compares the `url` it was initialized with the `url` of the metadata from the WebView. This also means that if any of these become out-of-sync, Strada components will stop working. This out-of-sync can happen when eg. the WebView's history changes with a Turbo Frame navigation.

In #227, a solution to this was to observe the native WebView's `url` and sync changes back to RN land. This works fine in iOS, but requires a lot of hacks to work on Android.

This PR fixes it in a different way by removing the `url` matching in Strada Components.

We originally introduced the `url` match assertion based on the Turbo Native iOS code. However, the implementation in React Native vs. Turbo Native iOS differ significantly; in React Native, we mount Bridge Components _with a key based on the url_, while in Turbo Native iOS, the bridge components are not removed when changing URL.

This means that in React Native, we can actually rely on the components being unmounted as navigation happens and the url changes. A new component will be mounted instead on the new url.

Based on this pattern, we can remove the `url` matching and assume that any messages received by the component with a matching name is related to _that_ url.

During my testing I saw that Strada Components were not being properly removed from the message listener queue when unmounted. This has also been addressed here.

## Test plan

As with #227, we can test that the Strada components work as expected by using the specific branch of the demo server.

I've created a branch on the demo web app that contains this: https://github.com/pfeiffer/turbo-native-demo/tree/test-turbo-frame-redirects

This can be checked out and the demo app pointed to the local running version of the test server.