### PR TITLE
Android: Fix `didOpenExternalUrl` not being called

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
@@ -8,6 +8,7 @@ import android.webkit.CookieManager
 import android.webkit.WebView
 import android.widget.LinearLayout
 import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -328,6 +329,12 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun visitProposedToLocation(location: String, options: VisitOptions) {
+    val currentUrl = webView?.url
+    if (currentUrl != null && currentUrl.toUri().host != location.toUri().host) {
+      didOpenExternalUrl(location)
+      return
+    }
+
     sendEvent(RNVisitableViewEvent.VISIT_PROPOSAL, Arguments.createMap().apply {
       putString("url", location)
       putString("action", options.action.name.lowercase())


### PR DESCRIPTION
Closes #233.

After changing the dependency to Hotwire Native Android, opening an external (cross-domain) URL does not trigger the `didOpenExternalUrl` method, as that has been removed from Hotwire Native Android.

This means all visit proposals, including ones that the navigators are not able to handle, as they are 'external', to be proposed for internal navigation.

This PR fixes this by comparing the host of the WebView with the host of the proposed location and calls `didOpenExternalUrl` instead.

Test plan:

1. Run demo app, tap `Follow an external link`. It should open the browser (default behavior)
2. Alternatively; add `onOpenExternalUrl={(location) => { console.log(location) }` to the `VisitableView`, tap external link, confirm that the location is logged to the console.