### PR TITLE
Android: Avoid doubble-triggering the `LOAD` event

### DIFF
--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
@@ -360,10 +360,6 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   override fun visitCompleted(completedOffline: Boolean) {
-    sendEvent(RNVisitableViewEvent.LOAD, Arguments.createMap().apply {
-      putString("title", webView!!.title)
-      putString("url", webView!!.url)
-    })
     CookieManager
       .getInstance()
       .flush()


### PR DESCRIPTION
## Summary
This PR fixes double-calling of `onLoad` on Android.
The `LOAD` event is triggered in `visitRendered`. The `visitRendered` callback is triggered both when restoring and when advancing by Hotwire Native.

The `visitCompleted` is called when a web page has been loaded in the WebView.

The `onLoad` callback could be fired twice - once via `visitCompleted` and once via `visitRendered`. This PR addresses that by only firing it via `visitRendered` which brings the behavior in-line with iOS.

## Test plan

Add a log statement to `onLoad`. Test on Android and open a screen and navigate around.

#### Before
```
 WARN  [useOnLoad] CALLED with: {"title": "Home", "url": "https://some-page.com/home"}
 WARN  [useOnLoad] CALLED with: {"title": "Home", "url": "https://some-page.com/home"}
```

#### After
```
 WARN  [useOnLoad] CALLED with: {"title": "Home", "url": "https://some-page.com/home"}
```