### PR TITLE
Ignore React Navigation internal keys when comparing minimal actions

### DIFF
--- a/packages/navigation/src/hooks/useWebviewNavigate.ts
+++ b/packages/navigation/src/hooks/useWebviewNavigate.ts
@@ -103,6 +103,9 @@ function areParamsSimilarForActionType(
     path: undefined,
     params: undefined,
     pop: undefined, // Ignore pop param added by React Navigation v7
+    state: undefined, // Ignore state as we drill down manually
+    initial: undefined, // Ignore initial as it's React Navigation internal
+    merge: undefined, // Ignore merge flag used in navigation actions
   } as object;
 
   if (actionType === 'replace') {

--- a/packages/navigation/src/hooks/useWebviewNavigate.ts
+++ b/packages/navigation/src/hooks/useWebviewNavigate.ts
@@ -102,6 +102,7 @@ function areParamsSimilarForActionType(
   let ignoredParams = {
     path: undefined,
     params: undefined,
+    pop: undefined, // Ignore pop param added by React Navigation v7
   } as object;
 
   if (actionType === 'replace') {


### PR DESCRIPTION
## Summary

`useWebViewNavigate` has logic to determine the minimum action to be dispatched to go from the current state to the new state when performing navigations.

When doing a `replace` visit, we'd like to update the screens params by dispatching a `SET_PARAMS` instead of a full `REPLACE` action if the two navigation states are similar enough (ie. same screen in same nesting).

React Navigation uses some internal keys that are part of the two states which are not relevant for the library when determining the minimal action, so we ignore those. However, there are a few additional keys that have been added in eg. React Navigation v7 that we also need to ignore.

This PR adds the additional keys to the ignored parameter list in `areParamsSimilarForActionType`.

These properties don't represent meaningful differences in navigation intent and should be ignored when determining if two routes are similar enough to dispatch a `SET_PARAMS` when performing a `replace` visit.

## Test plan

Have a screen with a route such as `/subscribe/:action?`.
Let the first screen load `/subscribe` that issue a `replace` visit to `/subscribe/checkout`.

Previously, this would result in a `REPLACE` action including an animation between the two screens.
After this PR we correctly update the params of the screen, so that no replace animation is shown.
