### PR TITLE
Support for New Architecture

### DIFF
--- a/packages/turbo/.codegenconfig
+++ b/packages/turbo/.codegenconfig
@@ -1,0 +1,8 @@
+{
+  "name": "RNHotwireNative",
+  "type": "modules",
+  "jsSrcsDir": "src",
+  "android": {
+    "javaPackageName": "com.reactnativehotwirewebview"
+  }
+}

--- a/packages/turbo/RNHotwireNative.podspec
+++ b/packages/turbo/RNHotwireNative.podspec
@@ -22,18 +22,18 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
 
-  # Don't install the dependencies when we run `pod install` in the old architecture.
-  if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
+  # New Architecture is required
+  s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
+  s.pod_target_xcconfig    = {
+      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+  }
 
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  end
+  s.dependency "React-Codegen"
+  s.dependency "RCT-Folly"
+  s.dependency "RCTRequired"
+  s.dependency "RCTTypeSafety"
+  s.dependency "ReactCommon/turbomodule/core"
+
+  install_modules_dependencies(s)
 end

--- a/packages/turbo/android/build.gradle
+++ b/packages/turbo/android/build.gradle
@@ -16,16 +16,9 @@ buildscript {
   }
 }
 
-def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
-}
-
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
-
-if (isNewArchitectureEnabled()) {
-  apply plugin: "com.facebook.react"
-}
+apply plugin: "com.facebook.react"
 
 def getExtOrDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties["HotwireWebview_" + name]
@@ -102,6 +95,11 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+}
+
+react {
+  libraryName = "RNHotwireNative"
+  codegenJavaPackageName = "com.reactnativehotwirewebview"
 }
 
 repositories {

--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNSession.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNSession.kt
@@ -106,9 +106,7 @@ class RNSession(
   inner class JavaScriptInterface {
     @JavascriptInterface
     fun postMessage(messageStr: String) {
-      // Android interface works only with primitive types, that's why we need to use JSON
-      val messageObj = Utils.convertJsonToMap(JSONObject(messageStr))
-      visitableView?.handleMessage(messageObj)
+      visitableView?.handleMessage(messageStr)
     }
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNSessionManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNSessionManager.kt
@@ -33,13 +33,11 @@ class RNSessionManager(reactContext: ReactApplicationContext) :
 
   @ReactMethod
   fun getSessionHandles(promise: Promise) {
-    if(sessions.keys.isNotEmpty()) {
-      val sessionHandles = Arguments.createArray()
-      sessions.keys.forEach {
-        sessionHandles.pushString(it)
-      }
-      promise.resolve(sessionHandles)
+    val sessionHandles = Arguments.createArray()
+    sessions.keys.forEach {
+      sessionHandles.pushString(it)
     }
+    promise.resolve(sessionHandles)
   }
 
   @ReactMethod

--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
@@ -296,7 +296,7 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
   }
 
   private fun sendEvent(event: RNVisitableViewEvent, params: WritableMap) {
-    reactContext.getJSModule(RCTEventEmitter::class.java).receiveEvent(id, event.name, params)
+    reactContext.getJSModule(RCTEventEmitter::class.java).receiveEvent(id, event.jsCallbackName, params)
   }
 
   // region SessionSubscriber
@@ -401,9 +401,8 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     onAlertHandler = null
   }
 
-  fun sendConfirmResult(result: String) {
-    val confirmResult = result == "true"
-    onConfirmHandler?.invoke(confirmResult)
+  fun sendConfirmResult(result: Boolean) {
+    onConfirmHandler?.invoke(result)
     onConfirmHandler = null
   }
 

--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableView.kt
@@ -305,8 +305,10 @@ class RNVisitableView(context: Context) : LinearLayout(context), SessionSubscrib
     webView?.evaluateJavascript(script, null)
   }
 
-  override fun handleMessage(message: WritableMap) {
-    sendEvent(RNVisitableViewEvent.MESSAGE, message)
+  override fun handleMessage(message: String) {
+    sendEvent(RNVisitableViewEvent.MESSAGE, Arguments.createMap().apply {
+      putString("message", message)
+    })
   }
 
   override fun didOpenExternalUrl(url: String) {

--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableViewManager.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNVisitableViewManager.kt
@@ -23,14 +23,6 @@ enum class RNVisitableViewEvent(val jsCallbackName: String) {
   CONTENT_PROCESS_DID_TERMINATE("onContentProcessDidTerminate")
 }
 
-enum class RNVisitableViewCommand(val jsCallbackName: String) {
-  INJECT_JAVASCRIPT("injectJavaScript"),
-  RELOAD_PAGE("reload"),
-  REFRESH_PAGE("refresh"),
-  SEND_ALERT_RESULT("sendAlertResult"),
-  SEND_CONFIRM_RESULT("sendConfirmResult")
-}
-
 private const val REACT_CLASS = "RNVisitableView"
 
 class RNVisitableViewManager(
@@ -74,38 +66,29 @@ class RNVisitableViewManager(
     view.webViewDebuggingEnabled = webViewDebuggingEnabled
   }
 
-  override fun getCommandsMap(): MutableMap<String, Int> = RNVisitableViewCommand.values()
-    .associate {
-      it.jsCallbackName to it.ordinal
-    }.toMutableMap()
-
   override fun receiveCommand(root: RNVisitableView, commandId: String, args: ReadableArray?) {
-    super.receiveCommand(root, commandId, args)
-    when (RNVisitableViewCommand.values()[commandId.toInt()]) {
-      RNVisitableViewCommand.INJECT_JAVASCRIPT -> {
+    when (commandId) {
+      "injectJavaScript" -> {
         args?.getString(0)?.let {
           root.injectJavaScript(it)
         }
       }
-      RNVisitableViewCommand.RELOAD_PAGE -> root.reload(true)
-      RNVisitableViewCommand.REFRESH_PAGE -> root.refresh()
-      RNVisitableViewCommand.SEND_ALERT_RESULT -> root.sendAlertResult()
-      RNVisitableViewCommand.SEND_CONFIRM_RESULT -> {
-        args?.getString(0)?.let {
+      "reload" -> root.reload(true)
+      "refresh" -> root.refresh()
+      "sendAlertResult" -> root.sendAlertResult()
+      "sendConfirmResult" -> {
+        args?.getBoolean(0)?.let {
           root.sendConfirmResult(it)
         }
       }
     }
   }
 
-  override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> =
-    RNVisitableViewEvent.values().associate {
-      it.name to mapOf(
-        "phasedRegistrationNames" to mapOf(
-          "bubbled" to it.jsCallbackName
-        )
-      )
+  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> {
+    return RNVisitableViewEvent.values().associate {
+      it.jsCallbackName to mapOf("registrationName" to it.jsCallbackName)
     }
+  }
 
   override fun createViewInstance(reactContext: ThemedReactContext) =
     RNVisitableView(
@@ -114,10 +97,10 @@ class RNVisitableViewManager(
 
   override fun onDropViewInstance(view: RNVisitableView) {
     super.onDropViewInstance(view)
-    
+
     // If the applicationContext is null, it can indicate that the application
     // has not been fully created yet or the application process is being terminated.
-    // In such cases, we stop the execution of the method. The similar check is done 
+    // In such cases, we stop the execution of the method. The similar check is done
     // in the `onDropViewInstance` method of the `ViewManager`.
     if (callerContext.applicationContext == null) {
       return

--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNWebChromeClient.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/RNWebChromeClient.kt
@@ -14,7 +14,6 @@ import com.facebook.react.bridge.ActivityEventListener
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.reactnativehotwirewebview.RNSession
 
 

--- a/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/SessionSubscriber.kt
+++ b/packages/turbo/android/src/main/java/com/reactnativehotwirewebview/SessionSubscriber.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.WritableMap
 
 interface SessionSubscriber: SessionCallbackAdapter {
   fun detachWebView()
-  fun handleMessage(message: WritableMap)
+  fun handleMessage(message: String)
   fun injectJavaScript(script: String)
   fun didOpenExternalUrl(url: String)
   fun didStartFormSubmission(url: String)

--- a/packages/turbo/ios/RNSession.swift
+++ b/packages/turbo/ios/RNSession.swift
@@ -121,7 +121,10 @@ extension RNSession: SessionDelegate {
 extension RNSession: WKScriptMessageHandler {
   
   func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-    visitableView?.handleMessage(message: message)
+    guard let body = message.body as? String else {
+      return
+    }
+    visitableView?.handleMessage(message: body)
   }
   
 }

--- a/packages/turbo/ios/RNSessionSubscriber.swift
+++ b/packages/turbo/ios/RNSessionSubscriber.swift
@@ -10,7 +10,7 @@ protocol RNSessionSubscriber {
   
   var id: UUID { get set }
   var controller: RNVisitableViewController? { get }
-  func handleMessage(message: WKScriptMessage)
+  func handleMessage(message: String)
   func didProposeVisit(proposal: VisitProposal)
   func didFailRequestForVisitable(visitable: Visitable, error: Error)
   func didOpenExternalUrl(url: URL)

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -172,10 +172,8 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     controller = nil
   }
     
-  public func handleMessage(message: WKScriptMessage) {
-    if let messageBody = message.body as? [AnyHashable : Any] {
-      onMessage?(messageBody)
-    }
+  public func handleMessage(message: String) {
+    onMessage?(["message": message])
   }
 
   public func injectJavaScript(code: NSString) -> Void {

--- a/packages/turbo/ios/RNVisitableView.swift
+++ b/packages/turbo/ios/RNVisitableView.swift
@@ -187,9 +187,8 @@ class RNVisitableView: UIView, RNSessionSubscriber {
     self.onAlertHandler = nil
   }
 
-  public func sendConfirmResult(result: NSString) -> Void {
-    let confirmResult = result == "true"
-    self.onConfirmHandler?(confirmResult)
+  public func sendConfirmResult(result: Bool) -> Void {
+    self.onConfirmHandler?(result)
     self.onConfirmHandler = nil
   }
 
@@ -305,7 +304,7 @@ extension RNVisitableView: RNVisitableViewControllerDelegate {
     // Ensure that all completion handlers have been called.
     // Otherwise, an NSInternalInconsistencyException might occur.
     sendAlertResult()
-    sendConfirmResult(result: "")
+    sendConfirmResult(result: false)
   }
 
   func visitableDidDisappear(visitable: Visitable) {

--- a/packages/turbo/ios/RNVisitableViewManager.m
+++ b/packages/turbo/ios/RNVisitableViewManager.m
@@ -40,7 +40,7 @@
   RCT_EXTERN_METHOD(refresh: (nonnull NSNumber) node)
   RCT_EXTERN_METHOD(sendAlertResult: (nonnull NSNumber) node)
   RCT_EXTERN_METHOD(sendConfirmResult: (nonnull NSNumber) node
-                    result: (nonnull NSString) code)
+                    result: (BOOL) result)
 
 
 @end

--- a/packages/turbo/ios/RNVisitableViewManager.swift
+++ b/packages/turbo/ios/RNVisitableViewManager.swift
@@ -51,7 +51,7 @@ class RNVisitableViewManager: RCTViewManager {
   }
 
   @objc
-  func sendConfirmResult(_ node: NSNumber, result: NSString) {
+  func sendConfirmResult(_ node: NSNumber, result: Bool) {
     DispatchQueue.main.async {
       let component = self.bridge.uiManager.view(forReactTag: node) as! RNVisitableView
       component.sendConfirmResult(result: result)

--- a/packages/turbo/package.json
+++ b/packages/turbo/package.json
@@ -43,7 +43,7 @@
     "@react-navigation/core": ">=6.0.0",
     "@react-navigation/native": ">=6.0.0",
     "react": "*",
-    "react-native": "*",
+    "react-native": ">=0.76.0",
     "react-native-safe-area-context": "5.2.0",
     "react-native-screens": "^4.10.0"
   },
@@ -53,6 +53,7 @@
     "android",
     "ios",
     "scripts/postinstall.sh",
+    ".codegenconfig",
     "RNHotwireNative.podspec",
     "!**/__tests__",
     "!**/__fixtures__",

--- a/packages/turbo/src/NativeRNSessionManager.ts
+++ b/packages/turbo/src/NativeRNSessionManager.ts
@@ -1,0 +1,11 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+export interface Spec extends TurboModule {
+  getSessionHandles(): Promise<string[]>;
+  reloadSession(sessionHandle: string): Promise<void>;
+  refreshSession(sessionHandle: string): Promise<void>;
+  clearSessionSnapshotCache(sessionHandle: string): Promise<void>;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('RNSessionManager');

--- a/packages/turbo/src/RNSessionManager.ts
+++ b/packages/turbo/src/RNSessionManager.ts
@@ -1,19 +1,8 @@
-import { NativeModules } from 'react-native';
-
-interface IRNSessionManager {
-  getSessionHandles(): Promise<string[]>;
-  reloadSession: (name: string) => Promise<void>;
-  refreshSession: (name: string) => Promise<void>;
-  clearSessionSnapshotCache: (name: string) => Promise<void>;
-}
-
-const { RNSessionManager } = NativeModules as {
-  RNSessionManager: IRNSessionManager;
-};
+import NativeRNSessionManager from './NativeRNSessionManager';
 
 export const {
   getSessionHandles,
   reloadSession,
   refreshSession,
   clearSessionSnapshotCache,
-} = RNSessionManager;
+} = NativeRNSessionManager;

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -1,12 +1,8 @@
 import {
   NativeSyntheticEvent,
-  Platform,
-  requireNativeComponent,
   StyleProp,
-  UIManager,
   ViewStyle,
   Linking,
-  findNodeHandle,
 } from 'react-native';
 
 import type {
@@ -22,6 +18,10 @@ import type {
   ContentInsetObject,
   ProgressViewOffsetObject,
 } from './types';
+
+import RNVisitableViewNativeComponent, {
+  Commands,
+} from './RNVisitableViewNativeComponent';
 
 // Interface should match RNVisitableView exported properties in native code
 export interface RNVisitableViewProps {
@@ -55,19 +55,6 @@ export interface RNVisitableViewProps {
   style?: StyleProp<ViewStyle>;
 }
 
-const LINKING_ERROR =
-  `The package react-native-turbo doesn't seem to be linked. Make sure: \n\n` +
-  Platform.select({ ios: "- You have run 'pod install'\n", default: '' }) +
-  '- You rebuilt the app after installing the package\n' +
-  '- You are not using Expo Go\n';
-
-function transformCommandToAcceptableType(command: number): number | string {
-  if (Platform.OS === 'ios') {
-    return command;
-  }
-  return command.toString();
-}
-
 const initializeWebView = async (webViewRef: React.RefObject<any>) => {
   const initializationPromise = new Promise<void>((resolve) =>
     setTimeout(resolve, 1)
@@ -88,17 +75,7 @@ export async function dispatchCommand(
   command: DispatchCommandTypes,
   ...args: any[]
 ) {
-  const viewConfig = UIManager.getViewManagerConfig('RNVisitableView');
-
-  if (!viewConfig) {
-    throw new Error(LINKING_ERROR);
-  }
-
-  const transformedCommand = transformCommandToAcceptableType(
-    viewConfig.Commands[command]!
-  );
-
-  if (transformedCommand === undefined) {
+  if (!ref?.current) {
     return;
   }
 
@@ -106,13 +83,23 @@ export async function dispatchCommand(
   // after the native sessionHandle prop is set.
   await initializeWebView(ref);
 
-  const reactTag = findNodeHandle(ref.current);
-
-  if (!reactTag) {
-    return;
+  switch (command) {
+    case 'injectJavaScript':
+      Commands.injectJavaScript(ref.current, args[0] as string);
+      break;
+    case 'reload':
+      Commands.reload(ref.current);
+      break;
+    case 'refresh':
+      Commands.refresh(ref.current);
+      break;
+    case 'sendAlertResult':
+      Commands.sendAlertResult(ref.current);
+      break;
+    case 'sendConfirmResult':
+      Commands.sendConfirmResult(ref.current, args[0] as boolean);
+      break;
   }
-
-  UIManager.dispatchViewManagerCommand(reactTag, transformedCommand, args);
 }
 
 export async function openExternalURL({
@@ -127,7 +114,4 @@ export async function openExternalURL({
   }
 }
 
-const RNVisitableView =
-  requireNativeComponent<RNVisitableViewProps>('RNVisitableView');
-
-export default RNVisitableView;
+export default RNVisitableViewNativeComponent;

--- a/packages/turbo/src/RNVisitableView.ts
+++ b/packages/turbo/src/RNVisitableView.ts
@@ -5,6 +5,9 @@ import {
   Linking,
 } from 'react-native';
 
+import RNVisitableViewNativeComponent, {
+  Commands,
+} from './RNVisitableViewNativeComponent';
 import type {
   AlertHandler,
   DispatchCommandTypes,
@@ -18,10 +21,6 @@ import type {
   ContentInsetObject,
   ProgressViewOffsetObject,
 } from './types';
-
-import RNVisitableViewNativeComponent, {
-  Commands,
-} from './RNVisitableViewNativeComponent';
 
 // Interface should match RNVisitableView exported properties in native code
 export interface RNVisitableViewProps {

--- a/packages/turbo/src/RNVisitableViewNativeComponent.ts
+++ b/packages/turbo/src/RNVisitableViewNativeComponent.ts
@@ -1,12 +1,12 @@
+import type { HostComponent, ViewProps } from 'react-native';
 import type {
   DirectEventHandler,
   Double,
   Int32,
   WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
-import type { HostComponent, ViewProps } from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
 // Event payload types
 export interface LoadEvent {
@@ -15,7 +15,7 @@ export interface LoadEvent {
 }
 
 // MessageEvent can contain arbitrary data from the web view
-export type MessageEvent = Readonly<{}>;
+export type MessageEvent = Readonly<object>;
 
 export interface ErrorEvent {
   url: string;
@@ -78,23 +78,35 @@ export interface NativeProps extends ViewProps {
   onOpenExternalUrl?: DirectEventHandler<OpenExternalUrlEvent>;
   onFormSubmissionStarted?: DirectEventHandler<FormSubmissionEvent>;
   onFormSubmissionFinished?: DirectEventHandler<FormSubmissionEvent>;
-  onShowLoading?: DirectEventHandler<{}>;
-  onHideLoading?: DirectEventHandler<{}>;
+  onShowLoading?: DirectEventHandler<object>;
+  onHideLoading?: DirectEventHandler<object>;
   onContentProcessDidTerminate?: DirectEventHandler<ContentProcessDidTerminateEvent>;
 }
 
 export type ComponentType = HostComponent<NativeProps>;
 
 interface NativeCommands {
-  injectJavaScript: (viewRef: React.ElementRef<ComponentType>, script: string) => void;
+  injectJavaScript: (
+    viewRef: React.ElementRef<ComponentType>,
+    script: string
+  ) => void;
   reload: (viewRef: React.ElementRef<ComponentType>) => void;
   refresh: (viewRef: React.ElementRef<ComponentType>) => void;
   sendAlertResult: (viewRef: React.ElementRef<ComponentType>) => void;
-  sendConfirmResult: (viewRef: React.ElementRef<ComponentType>, result: boolean) => void;
+  sendConfirmResult: (
+    viewRef: React.ElementRef<ComponentType>,
+    result: boolean
+  ) => void;
 }
 
 export const Commands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['injectJavaScript', 'reload', 'refresh', 'sendAlertResult', 'sendConfirmResult'],
+  supportedCommands: [
+    'injectJavaScript',
+    'reload',
+    'refresh',
+    'sendAlertResult',
+    'sendConfirmResult',
+  ],
 });
 
 export default codegenNativeComponent<NativeProps>('RNVisitableView');

--- a/packages/turbo/src/RNVisitableViewNativeComponent.ts
+++ b/packages/turbo/src/RNVisitableViewNativeComponent.ts
@@ -44,6 +44,10 @@ export interface ContentProcessDidTerminateEvent {
   url: string;
 }
 
+export interface ShowLoadingEvent {}
+
+export interface HideLoadingEvent {}
+
 export interface ContentInset {
   top?: WithDefault<Double, 0>;
   left?: WithDefault<Double, 0>;
@@ -78,8 +82,8 @@ export interface NativeProps extends ViewProps {
   onOpenExternalUrl?: DirectEventHandler<OpenExternalUrlEvent>;
   onFormSubmissionStarted?: DirectEventHandler<FormSubmissionEvent>;
   onFormSubmissionFinished?: DirectEventHandler<FormSubmissionEvent>;
-  onShowLoading?: DirectEventHandler<object>;
-  onHideLoading?: DirectEventHandler<object>;
+  onShowLoading?: DirectEventHandler<ShowLoadingEvent>;
+  onHideLoading?: DirectEventHandler<HideLoadingEvent>;
   onContentProcessDidTerminate?: DirectEventHandler<ContentProcessDidTerminateEvent>;
 }
 

--- a/packages/turbo/src/RNVisitableViewNativeComponent.ts
+++ b/packages/turbo/src/RNVisitableViewNativeComponent.ts
@@ -14,8 +14,9 @@ export interface LoadEvent {
   url: string;
 }
 
-// MessageEvent can contain arbitrary data from the web view
-export type MessageEvent = Readonly<object>;
+export type MessageEvent = {
+  message: string;
+};
 
 export interface ErrorEvent {
   url: string;

--- a/packages/turbo/src/RNVisitableViewNativeComponent.ts
+++ b/packages/turbo/src/RNVisitableViewNativeComponent.ts
@@ -1,0 +1,100 @@
+import type {
+  DirectEventHandler,
+  Double,
+  Int32,
+  WithDefault,
+} from 'react-native/Libraries/Types/CodegenTypes';
+import type { HostComponent, ViewProps } from 'react-native';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
+
+// Event payload types
+export interface LoadEvent {
+  title: string;
+  url: string;
+}
+
+// MessageEvent can contain arbitrary data from the web view
+export type MessageEvent = Readonly<{}>;
+
+export interface ErrorEvent {
+  url: string;
+  statusCode: Int32;
+  description?: string;
+}
+
+export interface VisitProposal {
+  url: string;
+  action: 'advance' | 'replace' | 'restore';
+}
+
+export interface AlertHandler {
+  message: string;
+}
+
+export interface OpenExternalUrlEvent {
+  url: string;
+}
+
+export interface FormSubmissionEvent {
+  url: string;
+}
+
+export interface ContentProcessDidTerminateEvent {
+  url: string;
+}
+
+export interface ContentInset {
+  top?: WithDefault<Double, 0>;
+  left?: WithDefault<Double, 0>;
+  bottom?: WithDefault<Double, 0>;
+  right?: WithDefault<Double, 0>;
+}
+
+export interface ProgressViewOffset {
+  scale: boolean;
+  start: Double;
+  end: Double;
+}
+
+export interface NativeProps extends ViewProps {
+  url: string;
+  sessionHandle?: string;
+  applicationNameForUserAgent?: string;
+  pullToRefreshEnabled?: WithDefault<boolean, false>;
+  scrollEnabled?: WithDefault<boolean, true>;
+  contentInset?: ContentInset;
+  progressViewOffset?: ProgressViewOffset;
+  refreshControlTopAnchor?: WithDefault<Double, 0>;
+  webViewDebuggingEnabled?: WithDefault<boolean, false>;
+
+  // Events
+  onLoad?: DirectEventHandler<LoadEvent>;
+  onMessage?: DirectEventHandler<MessageEvent>;
+  onError?: DirectEventHandler<ErrorEvent>;
+  onVisitProposal?: DirectEventHandler<VisitProposal>;
+  onWebAlert?: DirectEventHandler<AlertHandler>;
+  onWebConfirm?: DirectEventHandler<AlertHandler>;
+  onOpenExternalUrl?: DirectEventHandler<OpenExternalUrlEvent>;
+  onFormSubmissionStarted?: DirectEventHandler<FormSubmissionEvent>;
+  onFormSubmissionFinished?: DirectEventHandler<FormSubmissionEvent>;
+  onShowLoading?: DirectEventHandler<{}>;
+  onHideLoading?: DirectEventHandler<{}>;
+  onContentProcessDidTerminate?: DirectEventHandler<ContentProcessDidTerminateEvent>;
+}
+
+export type ComponentType = HostComponent<NativeProps>;
+
+interface NativeCommands {
+  injectJavaScript: (viewRef: React.ElementRef<ComponentType>, script: string) => void;
+  reload: (viewRef: React.ElementRef<ComponentType>) => void;
+  refresh: (viewRef: React.ElementRef<ComponentType>) => void;
+  sendAlertResult: (viewRef: React.ElementRef<ComponentType>) => void;
+  sendConfirmResult: (viewRef: React.ElementRef<ComponentType>, result: boolean) => void;
+}
+
+export const Commands = codegenNativeCommands<NativeCommands>({
+  supportedCommands: ['injectJavaScript', 'reload', 'refresh', 'sendAlertResult', 'sendConfirmResult'],
+});
+
+export default codegenNativeComponent<NativeProps>('RNVisitableView');

--- a/packages/turbo/src/hooks/useMessageQueue.ts
+++ b/packages/turbo/src/hooks/useMessageQueue.ts
@@ -29,8 +29,16 @@ export function useMessageQueue(
 
   const handleOnMessage = useCallback(
     (e: NativeSyntheticEvent<MessageEvent>) => {
+      let message: object;
+      try {
+        message = JSON.parse(e.nativeEvent.message);
+      } catch (error) {
+        console.error('Failed to parse message from native:', error);
+        return;
+      }
+
       onMessageCallbacks.current.forEach((listener) => {
-        listener?.(e.nativeEvent);
+        listener?.(message);
       });
     },
     []

--- a/packages/turbo/src/hooks/useWebViewDialogs.ts
+++ b/packages/turbo/src/hooks/useWebViewDialogs.ts
@@ -32,11 +32,7 @@ export function useWebViewDialogs(
   const handleConfirm = useCallback(
     ({ nativeEvent: { message } }: NativeSyntheticEvent<AlertHandler>) => {
       const dispatch = (value: boolean) =>
-        dispatchCommand(
-          visitableViewRef,
-          'sendConfirmResult',
-          value.toString()
-        );
+        dispatchCommand(visitableViewRef, 'sendConfirmResult', value);
 
       if (onConfirm) {
         onConfirm(message, (value) => dispatch(value));

--- a/packages/turbo/src/types.ts
+++ b/packages/turbo/src/types.ts
@@ -22,7 +22,9 @@ export interface ContentProcessDidTerminateEvent {
   url: string;
 }
 
-export type MessageEvent = object;
+export type MessageEvent = {
+  message: string;
+};
 
 export interface AlertHandler {
   message: string;

--- a/packages/turbo/src/utils/stradaBridgeScript.ts
+++ b/packages/turbo/src/utils/stradaBridgeScript.ts
@@ -79,9 +79,11 @@ export const stradaBridgeScript = `
     // Native handler
 
     postMessage(message) {
+      const messageString = JSON.stringify(message);
+
       ${Platform.select({
-        android: 'AndroidInterface.postMessage(JSON.stringify(message))',
-        ios: 'webkit.messageHandlers.nativeApp.postMessage(message)',
+        android: 'AndroidInterface.postMessage(messageString)',
+        ios: 'webkit.messageHandlers.nativeApp.postMessage(messageString)',
       })}
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,7 +1532,20 @@
     "@babel/parser" "^7.27.0"
     "@babel/types" "^7.27.0"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.10", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.8", "@babel/traverse@^7.27.0":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
+  version "7.27.0"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz"
+  integrity sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.27.0"
+    "@babel/parser" "^7.27.0"
+    "@babel/template" "^7.27.0"
+    "@babel/types" "^7.27.0"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.10", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.8", "@babel/traverse@^7.27.0":
   version "7.27.0"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz"
   integrity sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==
@@ -8870,9 +8883,9 @@ react-native-safe-area-context@5.2.0:
   integrity sha512-QpcGA6MRKe8Zbpf1hirCBudNQYGsMv0n/CTTROMOFcXbqRUoEXLCsYxUmYKi7JJb3ziL2DbyzWXyH2/gw4Tkfw==
 
 react-native-screens@^4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.10.0.tgz#40634aead590c6b7034ded6a9f92465d1d611906"
-  integrity sha512-Tw21NGuXm3PbiUGtZd0AnXirUixaAbPXDjNR0baBH7/WJDaDTTELLcQ7QRXuqAWbmr/EVCrKj1348ei1KFIr8A==
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.18.0.tgz#ba5a951b3f145e3b773d201143c19e1b1c1337ff"
+  integrity sha512-mRTLWL7Uc1p/RFNveEIIrhP22oxHduC2ZnLr/2iHwBeYpGXR0rJZ7Bgc0ktxQSHRjWTPT70qc/7yd4r9960PBQ==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
@@ -9725,7 +9738,16 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9801,7 +9823,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9814,6 +9836,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -10590,7 +10619,7 @@ wonka@^6.3.2:
   resolved "https://registry.npmjs.org/wonka/-/wonka-6.3.4.tgz"
   integrity sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10603,6 +10632,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR updates the library to require React Native 0.76+ and configures it for New Architecture compatibility via the interop layer.

## Breaking Changes
- **Minimum React Native version**: `>=0.76.0` (Expo SDK 52+)
- New Architecture must be enabled (RCT_NEW_ARCH_ENABLED=1)

### Build Configuration
- **iOS**: Removed conditional New Architecture checks, always enabled
- **Android**: Removed conditional checks, always apply React plugin with Codegen config

### JavaScript Layer
- Use `TurboModuleRegistry` instead of `NativeModules` for session manager
- Use Codegen-generated Commands for cleaner command dispatch
- Removed platform-specific command handling logic

### Message passing
- Changed message passing from JavaScript (WebView) -> native to always serialize to JSON for consistency between the platforms and to be able to generate codegen properly (ie. message is now always a string). We parse the JSON on the React Native side.

### Android Native Code
- **Fixed**: Changed events from bubbling to direct (consistency with iOS)
- String-based command routing instead of ordinal-based
- Minor cleanup: removed unnecessary empty array check in `getSessionHandles`
- Removed unused import in `RNWebChromeClient`

## Architecture Note
Native implementations remain on Paper architecture. The library runs via React Native's interop layer when New Architecture is enabled.