### PR TITLE
Fix race condition in Strada initialization

### DIFF
--- a/packages/turbo/src/hooks/useStradaBridge.ts
+++ b/packages/turbo/src/hooks/useStradaBridge.ts
@@ -12,8 +12,7 @@ export const useStradaBridge = (
     const stradaComponentNames =
       stradaComponents?.map(({ componentName }) => componentName) || [];
     const stradaInitializationScript = `
-      ${stradaBridgeScript}
-      window.nativeBridge.register(${JSON.stringify(stradaComponentNames)})
+      ${stradaBridgeScript(stradaComponentNames)}
     `;
 
     dispatchCommand(

--- a/packages/turbo/src/utils/stradaBridgeScript.ts
+++ b/packages/turbo/src/utils/stradaBridgeScript.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-export const stradaBridgeScript = `
+export const stradaBridgeScript = (stradaComponentNames: string[]) => `
 (() => {
   if(window.nativeBridge !== undefined){
     return;
@@ -109,6 +109,7 @@ export const stradaBridgeScript = `
 
   function initializeBridge() {
     window.nativeBridge = new NativeBridge();
+    window.nativeBridge.register(${JSON.stringify(stradaComponentNames)});
   }
 })();
 `;


### PR DESCRIPTION
## Summary

Fixes a potential calling of `window.nativeBridge` to register Strada components before the bridge is actually initialized.

In the Strada initialization script, we have the following snippet to initialize the bridge:

```
function initializeBridge() {
    window.nativeBridge = new NativeBridge();
}
```

This method is called dependent on the `document.readyState` or on `DOMContentLoaded`.

This means that `window.nativeBridge` could be undefined when we register the components of the Strada bridge from the React Native side.

This PR changes so that we register the available components at the same time as we initialize the bridge, making sure that the window.nativeBridge is available when we call that.

## Test plan

Run app with Strada components, confirm that they work.
